### PR TITLE
feat(ci): verrouiller les déploiements Coolify derrière une porte fail-closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dispatcher-tests:
+    name: Dispatcher tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Unit tests
+        run: python -m unittest discover tests -v
+      - name: Compile
+        run: python -m py_compile scripts/deploy_coolify.py scripts/merge_checked_pr.py

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -41,14 +41,30 @@ jobs:
           python-version: "3.12"
       - name: Validate dispatcher
         run: python -m unittest discover tests -v
-      - name: Gate exact SHA and deploy sequentially
+      - name: Gate exact SHA
+        if: inputs.dry_run
         env:
           FLEETWORK_GITHUB_READ_TOKEN: ${{ secrets.FLEETWORK_GITHUB_READ_TOKEN }}
           COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
           COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          INPUT_SERVICE: ${{ inputs.service }}
+          INPUT_SHA: ${{ inputs.sha }}
         run: >-
           python scripts/deploy_coolify.py
           --config config/coolify-services.json
-          --service '${{ inputs.service }}'
-          --sha '${{ inputs.sha }}'
-          ${{ inputs.dry_run && '--dry-run' || '' }}
+          --service "$INPUT_SERVICE"
+          --sha "$INPUT_SHA"
+          --dry-run
+      - name: Deploy the exact SHA sequentially
+        if: ${{ !inputs.dry_run }}
+        env:
+          FLEETWORK_GITHUB_READ_TOKEN: ${{ secrets.FLEETWORK_GITHUB_READ_TOKEN }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          INPUT_SERVICE: ${{ inputs.service }}
+          INPUT_SHA: ${{ inputs.sha }}
+        run: >-
+          python scripts/deploy_coolify.py
+          --config config/coolify-services.json
+          --service "$INPUT_SERVICE"
+          --sha "$INPUT_SHA"

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -1,0 +1,54 @@
+name: Deploy Coolify
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: Allowlisted production service
+        required: true
+        type: choice
+        options:
+          - web-worker
+          - agent-runner
+          - agent-coordinator
+      sha:
+        description: Full SHA currently at the repository main branch
+        required: true
+        type: string
+      dry_run:
+        description: Validate main and required checks without changing Coolify
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: production-fleetwork
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Validate and deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate dispatcher
+        run: python -m unittest discover tests -v
+      - name: Gate exact SHA and deploy sequentially
+        env:
+          FLEETWORK_GITHUB_READ_TOKEN: ${{ secrets.FLEETWORK_GITHUB_READ_TOKEN }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+        run: >-
+          python scripts/deploy_coolify.py
+          --config config/coolify-services.json
+          --service '${{ inputs.service }}'
+          --sha '${{ inputs.sha }}'
+          ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/.github/workflows/merge-checked-pr.yml
+++ b/.github/workflows/merge-checked-pr.yml
@@ -1,0 +1,47 @@
+name: Merge checked PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Allowlisted repository
+        required: true
+        type: choice
+        options:
+          - organization-workflows
+          - fleetwork-web
+          - agent-runner
+          - agent-coordinator
+          - deploy-notifier
+      pull_request:
+        description: Pull request number
+        required: true
+        type: number
+
+concurrency:
+  group: merge-${{ inputs.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  merge:
+    name: Validate exact head and merge
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate merge helper
+        run: python -m unittest discover tests -v
+      - name: Merge exact checked head
+        env:
+          FLEETWORK_GITHUB_WRITE_TOKEN: ${{ secrets.FLEETWORK_GITHUB_WRITE_TOKEN }}
+        run: >-
+          python scripts/merge_checked_pr.py
+          --config config/repositories.json
+          --repository '${{ inputs.repository }}'
+          --pr '${{ inputs.pull_request }}'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,30 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  secrets-scan:
+    name: Secrets (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        run: |
+          v=8.21.2
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${v}/gitleaks_${v}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+      - name: Scan for committed secrets
+        run: gitleaks detect --source . --redact --no-banner --exit-code 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
-# FleetWorkAI — .github
+# FleetWorkAI organization workflows
 
-Internal. Org-level community health files.
+`deploy-coolify.yml` is the only supported Coolify deployment entry point for
+FleetWork applications. It accepts an allowlisted logical service and the full
+SHA at that repository's current `main`.
+
+The dispatcher refuses a deployment when a required check is missing, pending
+or unsuccessful, when Coolify points at another repository or branch, when an
+environment key is duplicated, or when the deployed commit and fresh boot
+cannot be proven. The web and worker targets are always deployed sequentially.
+Dry-run performs the GitHub and Coolify preflights but does not pin a SHA or
+start a deployment.
+
+The `production` GitHub environment owns these secrets:
+
+- `FLEETWORK_GITHUB_READ_TOKEN`, read-only access to the private application repos;
+- `COOLIFY_URL`;
+- `COOLIFY_API_TOKEN`.
+
+The workflow never sends Telegram messages. The production notifier remains the
+single source for deployment success and failure notifications.
+
+`merge-checked-pr.yml` is the merge entry point after it has been bootstrapped.
+It rereads the current PR head, validates every required check on that exact SHA,
+then supplies the same SHA to GitHub's squash-merge API. It never enables an
+automatic merge.

--- a/config/coolify-services.json
+++ b/config/coolify-services.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "services": {
+    "web-worker": {
+      "repository": "FleetWorkAI/fleetwork-web",
+      "requiredChecks": [
+        "tsc + vitest",
+        "Secrets (gitleaks)",
+        "Dependencies (npm audit)"
+      ],
+      "targets": [
+        {
+          "name": "fleetwork-web",
+          "uuid": "yfhbnfncm8ec28qqbjbnu4cc",
+          "bootMarker": "Ready in|Next\\.js"
+        },
+        {
+          "name": "fleetwork-worker",
+          "uuid": "vq0yi3n9ldy1k4nxwywye9ge",
+          "bootMarker": "\\[worker\\] démarré"
+        }
+      ]
+    },
+    "agent-runner": {
+      "repository": "FleetWorkAI/agent-runner",
+      "requiredChecks": [
+        "cargo test",
+        "cargo build --release",
+        "Secrets (gitleaks)",
+        "Dependencies (cargo audit)"
+      ],
+      "targets": [
+        {
+          "name": "agent-runner",
+          "uuid": "yi0o3a7wwmc3bv5hhjx15ppi",
+          "bootMarker": "starting fleetwork orchestrator"
+        }
+      ]
+    },
+    "agent-coordinator": {
+      "repository": "FleetWorkAI/agent-coordinator",
+      "requiredChecks": [
+        "cargo test",
+        "Secrets (gitleaks)",
+        "Dependencies (cargo audit)"
+      ],
+      "targets": [
+        {
+          "name": "agent-coordinator",
+          "uuid": "ryhnzym3sqnv34qa7sh9i4ol",
+          "bootMarker": "starting fleetwork memory-session-layer"
+        }
+      ]
+    }
+  }
+}

--- a/config/repositories.json
+++ b/config/repositories.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "repositories": {
+    "organization-workflows": {
+      "repository": "FleetWorkAI/.github",
+      "requiredChecks": ["Dispatcher tests", "Secrets (gitleaks)"]
+    },
+    "fleetwork-web": {
+      "repository": "FleetWorkAI/fleetwork-web",
+      "requiredChecks": [
+        "tsc + vitest",
+        "Secrets (gitleaks)",
+        "Dependencies (npm audit)"
+      ]
+    },
+    "agent-runner": {
+      "repository": "FleetWorkAI/agent-runner",
+      "requiredChecks": [
+        "cargo test",
+        "cargo build --release",
+        "Secrets (gitleaks)",
+        "Dependencies (cargo audit)"
+      ]
+    },
+    "agent-coordinator": {
+      "repository": "FleetWorkAI/agent-coordinator",
+      "requiredChecks": [
+        "cargo test",
+        "Secrets (gitleaks)",
+        "Dependencies (cargo audit)"
+      ]
+    },
+    "deploy-notifier": {
+      "repository": "charlesDabard/deploy-notifier",
+      "requiredChecks": ["unittest", "Secrets (gitleaks)"]
+    }
+  }
+}

--- a/docs/baselines/2026-08-05-openrouter.md
+++ b/docs/baselines/2026-08-05-openrouter.md
@@ -1,0 +1,68 @@
+# Baseline OpenRouter et LiteLLM du 2026-08-05
+
+Photographie expurgée prise à `2026-08-05T13:58:03Z`. Elle ne contient ni
+secret, ni prompt, ni sortie de modèle, ni identifiant de société ou de run.
+
+## Secrets
+
+- La clé de gestion publiée dans la conversation a été désactivée dans
+  OpenRouter. Une requête d'authentification avec cette clé rend `401`.
+- Son remplacement rend `200`, expose bien `is_management_key=true` et peut
+  lire les crédits. Sa valeur est stockée dans le trousseau macOS sous le
+  service `fleetwork.openrouter.management`.
+- La clé d'inférence FleetWork est distincte, active, plafonnée à 15 USD et
+  avait consommé 0,0044791 USD lors de la photographie.
+- Aucun fichier temporaire contenant la nouvelle clé de gestion n'est conservé.
+
+## Catalogue réellement exposé
+
+`GET https://api.dev.fleetwork.ai/v1/models` avec la clé virtuelle du runner
+rend `200` et les alias suivants :
+
+- `claude-haiku-4-5`
+- `claude-opus-4-7`
+- `claude-sonnet-4-6`
+- `gpt-4o`
+- `gpt-4o-mini`
+- `gpt-5-nano`
+- `text-embedding-3-small`
+
+Les six alias de chat existent donc dans le proxy. L'embedding est une septième
+route interne et ne doit pas devenir sélectionnable.
+
+## Coûts des sept derniers jours
+
+Agrégat PostgreSQL en lecture seule sur `run_steps`, filtré par
+`COALESCE(started_at, finished_at) >= NOW() - INTERVAL '7 days'` :
+
+| Provenance | Étapes | Coût nul | Coût absent | Total micro-USD |
+| --- | ---: | ---: | ---: | ---: |
+| `litellm` | 10 | 0 | 0 | 5 608 |
+| `estimated` | 9 | 0 | 0 | 19 571 |
+
+Total : 19 étapes et 25 179 micro-USD. La mesure LiteLLM couvre 52,6 % des
+étapes ; 47,4 % restent estimées. Les dix-neuf étapes sont `succeeded` : une
+Claude Haiku 4.5, huit GPT-4o mini et dix GPT-5 nano.
+
+## Défauts de configuration confirmés
+
+- `MAX_COST_MICRO_USD_PER_RUN` est absent du runner déployé. Son défaut de code
+  vaut `0`, donc le plafond global est désactivé.
+- `LITELLM_SPEND_API_KEY` est absent du runner déployé.
+- La clé de complétion du runner obtient `401` sur `/spend/logs`, ce qui confirme
+  qu'elle ne peut pas remplacer la clé de lecture dédiée.
+- `LITELLM_DEFAULT_MODEL` vaut `gpt-5-nano` en production.
+- Le runner conserve le `request_id` reçu dans les chunks SSE, mais ne génère
+  ni ne persiste encore de `correlation_id` serveur. Un crash après émission et
+  avant réponse reste donc ambigu et ne doit pas être rejoué automatiquement.
+- La variable locale nommée `PROD_LITELLM_API_KEY` ne s'authentifie pas auprès
+  du proxy. Les opérations ont utilisé la vraie clé virtuelle montée sur le
+  runner ; le nommage local doit être corrigé sans recopier de secret.
+
+## Coolify
+
+Le contrôle expurgé des environnements web, worker, runner et coordinator rend
+zéro doublon réel par couple `(key, is_preview)`. Les paires production/preview
+sont deux scopes légitimes et ne doivent pas être supprimées. Le dry-run du
+dispatcher central valide les dépôts, la branche `main`, les checks des SHA
+courants et ces quatre environnements sans mutation.

--- a/scripts/deploy_coolify.py
+++ b/scripts/deploy_coolify.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Fail-closed deployment gate shared by FleetWork production services."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SUCCESS = "success"
+TERMINAL_FAILURES = {"cancelled", "error", "failed"}
+
+
+class GateError(RuntimeError):
+    """A validation or deployment invariant failed."""
+
+
+class JsonClient:
+    def __init__(self, base_url: str, token: str, user_agent: str):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.user_agent = user_agent
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        accept: str = "application/json",
+    ) -> Any:
+        body = None if payload is None else json.dumps(payload).encode()
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": accept,
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": self.user_agent,
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as error:
+            error.read()
+            raise GateError(f"{method} {path} returned HTTP {error.code}") from error
+        except urllib.error.URLError as error:
+            raise GateError(f"{method} {path} is unavailable") from error
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise GateError(f"{method} {path} returned invalid JSON") from error
+
+    def get(self, path: str, accept: str = "application/json") -> Any:
+        return self.request("GET", path, accept=accept)
+
+    def patch(self, path: str, payload: dict[str, Any]) -> Any:
+        return self.request("PATCH", path, payload=payload)
+
+    def put(self, path: str, payload: dict[str, Any]) -> Any:
+        return self.request("PUT", path, payload=payload)
+
+
+@dataclass(frozen=True)
+class Target:
+    name: str
+    uuid: str
+    boot_marker: str
+
+
+@dataclass(frozen=True)
+class Service:
+    name: str
+    repository: str
+    required_checks: tuple[str, ...]
+    targets: tuple[Target, ...]
+
+
+def load_service(config_path: Path, service_name: str) -> Service:
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise GateError(f"cannot read config {config_path}") from error
+    if config.get("schemaVersion") != 1 or not isinstance(config.get("services"), dict):
+        raise GateError("unsupported deployment config schema")
+    raw = config["services"].get(service_name)
+    if not isinstance(raw, dict):
+        raise GateError(f"service {service_name!r} is not allowlisted")
+    repository = raw.get("repository")
+    checks = raw.get("requiredChecks")
+    target_rows = raw.get("targets")
+    if not isinstance(repository, str) or not re.fullmatch(r"FleetWorkAI/[A-Za-z0-9_.-]+", repository):
+        raise GateError("invalid allowlisted repository")
+    if not isinstance(checks, list) or not checks or any(not isinstance(item, str) for item in checks):
+        raise GateError("requiredChecks must be a non-empty string list")
+    if len(set(checks)) != len(checks):
+        raise GateError("requiredChecks contains duplicates")
+    if not isinstance(target_rows, list) or not target_rows:
+        raise GateError("targets must be a non-empty list")
+    targets: list[Target] = []
+    seen_uuids: set[str] = set()
+    for row in target_rows:
+        if not isinstance(row, dict):
+            raise GateError("invalid target")
+        name, uuid, marker = row.get("name"), row.get("uuid"), row.get("bootMarker")
+        if not all(isinstance(item, str) and item for item in (name, uuid, marker)):
+            raise GateError("target name, uuid and bootMarker are required")
+        if uuid in seen_uuids:
+            raise GateError("a Coolify UUID appears more than once")
+        try:
+            re.compile(marker)
+        except re.error as error:
+            raise GateError(f"invalid boot marker for {name}") from error
+        seen_uuids.add(uuid)
+        targets.append(Target(name=name, uuid=uuid, boot_marker=marker))
+    return Service(
+        name=service_name,
+        repository=repository,
+        required_checks=tuple(checks),
+        targets=tuple(targets),
+    )
+
+
+def validate_sha(sha: str) -> str:
+    normalized = sha.lower()
+    if not SHA_RE.fullmatch(normalized):
+        raise GateError("sha must be a full 40-character Git commit")
+    return normalized
+
+
+def latest_required_checks(check_runs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for run in check_runs:
+        if run.get("head_sha") is None or run.get("app", {}).get("slug") != "github-actions":
+            continue
+        name = run.get("name")
+        if not isinstance(name, str):
+            continue
+        current = latest.get(name)
+        if current is None or int(run.get("id", 0)) > int(current.get("id", 0)):
+            latest[name] = run
+    return latest
+
+
+def verify_required_checks(
+    github: JsonClient,
+    repository: str,
+    sha: str,
+    required_checks: tuple[str, ...],
+) -> None:
+    repo_path = "/repos/" + urllib.parse.quote(repository, safe="/")
+    checks = github.get(
+        f"{repo_path}/commits/{sha}/check-runs?filter=latest&per_page=100",
+        accept="application/vnd.github+json",
+    )
+    if not isinstance(checks, dict) or not isinstance(checks.get("check_runs"), list):
+        raise GateError("GitHub returned an invalid checks response")
+    if int(checks.get("total_count", 0)) > len(checks["check_runs"]):
+        raise GateError("more than 100 checks found; refusing an incomplete evaluation")
+    latest = latest_required_checks(checks["check_runs"])
+    problems: list[str] = []
+    for name in required_checks:
+        run = latest.get(name)
+        if run is None:
+            problems.append(f"{name}: missing")
+        elif run.get("head_sha", "").lower() != sha:
+            problems.append(f"{name}: wrong sha")
+        elif run.get("status") != "completed" or run.get("conclusion") != SUCCESS:
+            problems.append(f"{name}: {run.get('status')}/{run.get('conclusion')}")
+    if problems:
+        raise GateError("required checks are not green: " + ", ".join(problems))
+
+
+def verify_github(github: JsonClient, service: Service, sha: str) -> None:
+    repo_path = "/repos/" + urllib.parse.quote(service.repository, safe="/")
+    main = github.get(f"{repo_path}/commits/main")
+    if not isinstance(main, dict) or str(main.get("sha", "")).lower() != sha:
+        raise GateError(f"{sha[:8]} is not the current main of {service.repository}")
+    verify_required_checks(github, service.repository, sha, service.required_checks)
+
+
+def env_keys(rows: Any) -> list[tuple[str, bool]]:
+    if isinstance(rows, dict):
+        rows = rows.get("data", [])
+    if not isinstance(rows, list):
+        raise GateError("Coolify returned invalid environment variables")
+    keys: list[tuple[str, bool]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        key = row.get("key") or row.get("name")
+        if isinstance(key, str) and key:
+            keys.append((key, bool(row.get("is_preview"))))
+    return keys
+
+
+def assert_no_duplicate_env(coolify: JsonClient, target: Target) -> None:
+    keys = env_keys(coolify.get(f"/applications/{target.uuid}/envs"))
+    duplicates = sorted({key for key in keys if keys.count(key) > 1})
+    if duplicates:
+        labels = [f"{key}[{'preview' if preview else 'production'}]" for key, preview in duplicates]
+        raise GateError(f"{target.name} has duplicate environment keys: {', '.join(labels)}")
+
+
+def preflight_target(coolify: JsonClient, service: Service, target: Target) -> dict[str, Any]:
+    application = coolify.get(f"/applications/{target.uuid}")
+    if not isinstance(application, dict):
+        raise GateError(f"invalid Coolify application {target.name}")
+    if application.get("name") != target.name:
+        raise GateError(f"Coolify name mismatch for {target.name}")
+    if application.get("git_repository") != service.repository:
+        raise GateError(f"Coolify repository mismatch for {target.name}")
+    if application.get("git_branch") != "main":
+        raise GateError(f"{target.name} does not track main")
+    assert_no_duplicate_env(coolify, target)
+    return application
+
+
+def deployment_uuid(payload: Any) -> str:
+    if isinstance(payload, dict):
+        direct = payload.get("deployment_uuid")
+        if isinstance(direct, str) and direct:
+            return direct
+        deployments = payload.get("deployments")
+        if isinstance(deployments, list) and deployments:
+            found = deployments[0].get("deployment_uuid")
+            if isinstance(found, str) and found:
+                return found
+    raise GateError("Coolify did not return a deployment UUID")
+
+
+def wait_for_terminal(
+    coolify: JsonClient,
+    deploy_uuid: str,
+    timeout_seconds: int,
+    poll_seconds: int,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_status = None
+    while time.monotonic() < deadline:
+        state = coolify.get(f"/deployments/{deploy_uuid}")
+        if not isinstance(state, dict):
+            raise GateError("Coolify returned an invalid deployment state")
+        status = state.get("status")
+        if status != last_status:
+            print(f"deployment {deploy_uuid}: {status}", flush=True)
+            last_status = status
+        if status == "finished":
+            return state
+        if status in TERMINAL_FAILURES:
+            raise GateError(f"deployment {deploy_uuid} ended with {status}")
+        time.sleep(poll_seconds)
+    raise GateError(f"deployment {deploy_uuid} did not finish before timeout")
+
+
+def deploy_target(
+    coolify: JsonClient,
+    service: Service,
+    target: Target,
+    sha: str,
+    timeout_seconds: int,
+    poll_seconds: int,
+) -> str:
+    before = preflight_target(coolify, service, target)
+    previous_restart = before.get("last_restart_at")
+    coolify.patch(f"/applications/{target.uuid}", {"git_commit_sha": sha})
+    pinned = coolify.get(f"/applications/{target.uuid}")
+    if not isinstance(pinned, dict) or str(pinned.get("git_commit_sha", "")).lower() != sha:
+        raise GateError(f"Coolify did not retain the exact SHA for {target.name}")
+    triggered = coolify.get(f"/deploy?uuid={urllib.parse.quote(target.uuid)}&force=false")
+    deploy_uuid = deployment_uuid(triggered)
+    state = wait_for_terminal(coolify, deploy_uuid, timeout_seconds, poll_seconds)
+    deployed_sha = state.get("commit") or state.get("git_commit_sha")
+    if not isinstance(deployed_sha, str) or deployed_sha.lower() != sha:
+        raise GateError(f"deployment {deploy_uuid} did not prove commit {sha[:8]}")
+    after = coolify.get(f"/applications/{target.uuid}")
+    if not isinstance(after, dict) or str(after.get("git_commit_sha", "")).lower() != sha:
+        raise GateError(f"{target.name} no longer pins the approved SHA")
+    if "running" not in str(after.get("status", "")):
+        raise GateError(f"{target.name} is not running after deployment")
+    current_restart = after.get("last_restart_at")
+    if not current_restart or current_restart == previous_restart:
+        raise GateError(f"{target.name} has no fresh restart marker")
+    logs_payload = coolify.get(f"/applications/{target.uuid}/logs?lines=200")
+    logs = logs_payload.get("logs", "") if isinstance(logs_payload, dict) else str(logs_payload)
+    if re.search(target.boot_marker, logs, flags=re.IGNORECASE) is None:
+        raise GateError(f"{target.name} fresh logs lack its boot marker")
+    return deploy_uuid
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--timeout-seconds", type=int, default=2400)
+    parser.add_argument("--poll-seconds", type=int, default=10)
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    service = load_service(args.config, args.service)
+    sha = validate_sha(args.sha)
+    github_token = os.environ.get("FLEETWORK_GITHUB_READ_TOKEN", "")
+    if not github_token:
+        raise GateError("FLEETWORK_GITHUB_READ_TOKEN is required")
+    github = JsonClient("https://api.github.com", github_token, "fleetwork-deploy-gate/1")
+    verify_github(github, service, sha)
+    coolify_url = os.environ.get("COOLIFY_URL", "").rstrip("/")
+    coolify_token = os.environ.get("COOLIFY_API_TOKEN", "")
+    if not coolify_url.startswith("https://") or not coolify_token:
+        raise GateError("COOLIFY_URL and COOLIFY_API_TOKEN are required")
+    coolify = JsonClient(f"{coolify_url}/api/v1", coolify_token, "fleetwork-deploy-gate/1")
+    if args.dry_run:
+        for target in service.targets:
+            preflight_target(coolify, service, target)
+        return {
+            "status": "validated",
+            "service": service.name,
+            "sha": sha,
+            "targets": [target.name for target in service.targets],
+        }
+    deployed: list[dict[str, str]] = []
+    for target in service.targets:
+        deploy_uuid = deploy_target(
+            coolify,
+            service,
+            target,
+            sha,
+            args.timeout_seconds,
+            args.poll_seconds,
+        )
+        deployed.append({"target": target.name, "deployment": deploy_uuid})
+    return {"status": "finished", "service": service.name, "sha": sha, "deployed": deployed}
+
+
+def main() -> int:
+    try:
+        result = run(build_parser().parse_args())
+    except GateError as error:
+        print(f"deployment gate refused: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_checked_pr.py
+++ b/scripts/merge_checked_pr.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Merge one exact PR head after fail-closed required-check validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    from .deploy_coolify import GateError, JsonClient, validate_sha, verify_required_checks
+except ImportError:  # Direct CLI execution puts scripts/ itself on sys.path.
+    from deploy_coolify import GateError, JsonClient, validate_sha, verify_required_checks
+
+
+@dataclass(frozen=True)
+class RepositoryPolicy:
+    name: str
+    repository: str
+    required_checks: tuple[str, ...]
+
+
+def load_policy(config_path: Path, policy_name: str) -> RepositoryPolicy:
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise GateError(f"cannot read config {config_path}") from error
+    rows = config.get("repositories")
+    if config.get("schemaVersion") != 1 or not isinstance(rows, dict):
+        raise GateError("unsupported repository config schema")
+    row = rows.get(policy_name)
+    if not isinstance(row, dict):
+        raise GateError(f"repository policy {policy_name!r} is not allowlisted")
+    repository = row.get("repository")
+    checks = row.get("requiredChecks")
+    if not isinstance(repository, str) or not re.fullmatch(
+        r"(?:FleetWorkAI|charlesDabard)/[A-Za-z0-9_.-]+", repository
+    ):
+        raise GateError("invalid allowlisted repository")
+    if not isinstance(checks, list) or not checks or any(not isinstance(item, str) for item in checks):
+        raise GateError("requiredChecks must be a non-empty string list")
+    if len(set(checks)) != len(checks):
+        raise GateError("requiredChecks contains duplicates")
+    return RepositoryPolicy(policy_name, repository, tuple(checks))
+
+
+def merge_pr(github: JsonClient, policy: RepositoryPolicy, pr_number: int) -> dict[str, Any]:
+    if pr_number <= 0:
+        raise GateError("pull request number must be positive")
+    repo_path = "/repos/" + urllib.parse.quote(policy.repository, safe="/")
+    pull = github.get(f"{repo_path}/pulls/{pr_number}")
+    if not isinstance(pull, dict):
+        raise GateError("GitHub returned an invalid pull request")
+    if pull.get("state") != "open" or pull.get("draft") is True:
+        raise GateError("pull request must be open and ready for review")
+    if pull.get("base", {}).get("ref") != "main":
+        raise GateError("pull request base must be main")
+    head_sha = validate_sha(str(pull.get("head", {}).get("sha", "")))
+    if pull.get("mergeable") is not True:
+        raise GateError("pull request is not currently mergeable")
+    verify_required_checks(github, policy.repository, head_sha, policy.required_checks)
+    result = github.put(
+        f"{repo_path}/pulls/{pr_number}/merge",
+        {"sha": head_sha, "merge_method": "squash"},
+    )
+    if not isinstance(result, dict) or result.get("merged") is not True:
+        raise GateError("GitHub refused the exact-head merge")
+    merge_sha = validate_sha(str(result.get("sha", "")))
+    return {
+        "status": "merged",
+        "repository": policy.repository,
+        "pullRequest": pr_number,
+        "headSha": head_sha,
+        "mergeSha": merge_sha,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr", type=int, required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        policy = load_policy(args.config, args.repository)
+        token = os.environ.get("FLEETWORK_GITHUB_WRITE_TOKEN", "")
+        if not token:
+            raise GateError("FLEETWORK_GITHUB_WRITE_TOKEN is required")
+        github = JsonClient("https://api.github.com", token, "fleetwork-merge-gate/1")
+        result = merge_pr(github, policy, args.pr)
+    except GateError as error:
+        print(f"merge gate refused: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_coolify.py
+++ b/tests/test_deploy_coolify.py
@@ -1,0 +1,209 @@
+import argparse
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.deploy_coolify import (
+    GateError,
+    Service,
+    Target,
+    assert_no_duplicate_env,
+    deploy_target,
+    load_service,
+    preflight_target,
+    validate_sha,
+    verify_github,
+)
+
+
+SHA = "a" * 40
+
+
+class FakeClient:
+    def __init__(self, routes=None):
+        self.routes = routes or {}
+        self.calls = []
+
+    def get(self, path, accept="application/json"):
+        self.calls.append(("GET", path))
+        value = self.routes.get(("GET", path))
+        if isinstance(value, tuple):
+            if not value:
+                raise AssertionError(f"no fake response left for {path}")
+            self.routes[("GET", path)] = value[1:]
+            return value[0]
+        if value is None:
+            raise AssertionError(f"unexpected GET {path}")
+        return value
+
+    def patch(self, path, payload):
+        self.calls.append(("PATCH", path, payload))
+        value = self.routes.get(("PATCH", path))
+        return {} if value is None else value
+
+
+def service():
+    return Service(
+        name="runner",
+        repository="FleetWorkAI/agent-runner",
+        required_checks=("cargo test", "Security"),
+        targets=(Target("agent-runner", "runner-uuid", "starting runner"),),
+    )
+
+
+def check(name, conclusion="success", run_id=1):
+    return {
+        "id": run_id,
+        "name": name,
+        "head_sha": SHA,
+        "status": "completed",
+        "conclusion": conclusion,
+        "app": {"slug": "github-actions"},
+    }
+
+
+class ConfigTests(unittest.TestCase):
+    def test_sha_requires_full_commit(self):
+        with self.assertRaisesRegex(GateError, "40-character"):
+            validate_sha("abc123")
+
+    def test_unknown_service_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.json"
+            path.write_text(json.dumps({"schemaVersion": 1, "services": {}}))
+            with self.assertRaisesRegex(GateError, "not allowlisted"):
+                load_service(path, "unknown")
+
+    def test_duplicate_target_uuid_is_refused(self):
+        config = {
+            "schemaVersion": 1,
+            "services": {
+                "x": {
+                    "repository": "FleetWorkAI/x",
+                    "requiredChecks": ["CI"],
+                    "targets": [
+                        {"name": "a", "uuid": "same", "bootMarker": "ready"},
+                        {"name": "b", "uuid": "same", "bootMarker": "ready"},
+                    ],
+                }
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.json"
+            path.write_text(json.dumps(config))
+            with self.assertRaisesRegex(GateError, "more than once"):
+                load_service(path, "x")
+
+
+class GithubGateTests(unittest.TestCase):
+    def github(self, checks, main_sha=SHA, total_count=None):
+        repo = "/repos/FleetWorkAI/agent-runner"
+        return FakeClient(
+            {
+                ("GET", f"{repo}/commits/main"): {"sha": main_sha},
+                ("GET", f"{repo}/commits/{SHA}/check-runs?filter=latest&per_page=100"): {
+                    "total_count": len(checks) if total_count is None else total_count,
+                    "check_runs": checks,
+                },
+            }
+        )
+
+    def test_current_main_with_green_checks_passes(self):
+        verify_github(self.github([check("cargo test"), check("Security")]), service(), SHA)
+
+    def test_sha_other_than_main_is_refused(self):
+        with self.assertRaisesRegex(GateError, "not the current main"):
+            verify_github(self.github([], main_sha="b" * 40), service(), SHA)
+
+    def test_missing_or_failed_check_is_refused(self):
+        with self.assertRaisesRegex(GateError, "cargo test: completed/failure, Security: missing"):
+            verify_github(self.github([check("cargo test", "failure")]), service(), SHA)
+
+    def test_latest_rerun_is_authoritative(self):
+        runs = [check("cargo test", "failure", 1), check("cargo test", "success", 2), check("Security")]
+        verify_github(self.github(runs), service(), SHA)
+
+    def test_incomplete_check_page_is_refused(self):
+        with self.assertRaisesRegex(GateError, "incomplete evaluation"):
+            verify_github(self.github([check("cargo test")], total_count=101), service(), SHA)
+
+
+class CoolifyGateTests(unittest.TestCase):
+    def test_duplicate_environment_keys_are_refused_without_values(self):
+        client = FakeClient({("GET", "/applications/runner-uuid/envs"): [
+            {"key": "TOKEN", "value": "first", "is_preview": False},
+            {"key": "TOKEN", "value": "second", "is_preview": False},
+        ]})
+        with self.assertRaisesRegex(GateError, r"TOKEN\[production\]"):
+            assert_no_duplicate_env(client, service().targets[0])
+
+    def test_production_and_preview_rows_are_distinct_scopes(self):
+        client = FakeClient({("GET", "/applications/runner-uuid/envs"): [
+            {"key": "TOKEN", "value": "production", "is_preview": False},
+            {"key": "TOKEN", "value": "preview", "is_preview": True},
+        ]})
+        assert_no_duplicate_env(client, service().targets[0])
+
+    def test_preflight_refuses_a_repository_mismatch_without_mutation(self):
+        client = FakeClient({("GET", "/applications/runner-uuid"): {
+            "name": "agent-runner",
+            "git_repository": "FleetWorkAI/wrong",
+            "git_branch": "main",
+        }})
+        with self.assertRaisesRegex(GateError, "repository mismatch"):
+            preflight_target(client, service(), service().targets[0])
+        self.assertFalse(any(call[0] == "PATCH" for call in client.calls))
+
+    @patch("scripts.deploy_coolify.time.sleep", return_value=None)
+    def test_deploy_pins_sha_and_proves_fresh_boot(self, _sleep):
+        app_before = {
+            "name": "agent-runner",
+            "git_repository": "FleetWorkAI/agent-runner",
+            "git_branch": "main",
+            "git_commit_sha": "HEAD",
+            "last_restart_at": "before",
+            "status": "running:healthy",
+        }
+        app_after = {**app_before, "git_commit_sha": SHA, "last_restart_at": "after"}
+        client = FakeClient(
+            {
+                ("GET", "/applications/runner-uuid"): (app_before, app_after, app_after),
+                ("GET", "/applications/runner-uuid/envs"): [{"key": "ONE"}],
+                ("GET", "/deploy?uuid=runner-uuid&force=false"): {"deployment_uuid": "dep-1"},
+                ("GET", "/deployments/dep-1"): {"status": "finished", "commit": SHA},
+                ("GET", "/applications/runner-uuid/logs?lines=200"): {
+                    "logs": "starting runner"
+                },
+            }
+        )
+        deploy_id = deploy_target(client, service(), service().targets[0], SHA, 1, 0)
+        self.assertEqual(deploy_id, "dep-1")
+        self.assertIn(("PATCH", "/applications/runner-uuid", {"git_commit_sha": SHA}), client.calls)
+
+    @patch("scripts.deploy_coolify.time.sleep", return_value=None)
+    def test_deployment_commit_mismatch_is_refused(self, _sleep):
+        app = {
+            "name": "agent-runner",
+            "git_repository": "FleetWorkAI/agent-runner",
+            "git_branch": "main",
+            "git_commit_sha": SHA,
+            "last_restart_at": "before",
+            "status": "running:healthy",
+        }
+        client = FakeClient(
+            {
+                ("GET", "/applications/runner-uuid"): (app, app),
+                ("GET", "/applications/runner-uuid/envs"): [],
+                ("GET", "/deploy?uuid=runner-uuid&force=false"): {"deployment_uuid": "dep-1"},
+                ("GET", "/deployments/dep-1"): {"status": "finished", "commit": "b" * 40},
+            }
+        )
+        with self.assertRaisesRegex(GateError, "did not prove commit"):
+            deploy_target(client, service(), service().targets[0], SHA, 1, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_checked_pr.py
+++ b/tests/test_merge_checked_pr.py
@@ -1,0 +1,105 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.deploy_coolify import GateError
+from scripts.merge_checked_pr import RepositoryPolicy, load_policy, merge_pr
+
+
+SHA = "a" * 40
+MERGE_SHA = "b" * 40
+
+
+def check(name, conclusion="success"):
+    return {
+        "id": 1,
+        "name": name,
+        "head_sha": SHA,
+        "status": "completed",
+        "conclusion": conclusion,
+        "app": {"slug": "github-actions"},
+    }
+
+
+class FakeGithub:
+    def __init__(self, pull=None, checks=None, merge=None):
+        self.pull = pull or {
+            "state": "open",
+            "draft": False,
+            "mergeable": True,
+            "base": {"ref": "main"},
+            "head": {"sha": SHA},
+        }
+        self.checks = checks or [check("CI"), check("Security")]
+        self.merge = merge or {"merged": True, "sha": MERGE_SHA}
+        self.calls = []
+
+    def get(self, path, accept="application/json"):
+        self.calls.append(("GET", path))
+        if path.endswith("/pulls/12"):
+            return self.pull
+        if "/check-runs?" in path:
+            return {"total_count": len(self.checks), "check_runs": self.checks}
+        raise AssertionError(f"unexpected GET {path}")
+
+    def put(self, path, payload):
+        self.calls.append(("PUT", path, payload))
+        return self.merge
+
+
+POLICY = RepositoryPolicy("runner", "FleetWorkAI/agent-runner", ("CI", "Security"))
+
+
+class MergeGateTests(unittest.TestCase):
+    def test_exact_green_head_is_squash_merged(self):
+        github = FakeGithub()
+        result = merge_pr(github, POLICY, 12)
+        self.assertEqual(result["headSha"], SHA)
+        self.assertIn(
+            (
+                "PUT",
+                "/repos/FleetWorkAI/agent-runner/pulls/12/merge",
+                {"sha": SHA, "merge_method": "squash"},
+            ),
+            github.calls,
+        )
+
+    def test_draft_is_refused_before_checks_or_merge(self):
+        github = FakeGithub(pull={
+            "state": "open",
+            "draft": True,
+            "mergeable": True,
+            "base": {"ref": "main"},
+            "head": {"sha": SHA},
+        })
+        with self.assertRaisesRegex(GateError, "ready for review"):
+            merge_pr(github, POLICY, 12)
+        self.assertFalse(any(call[0] == "PUT" for call in github.calls))
+
+    def test_non_main_base_is_refused(self):
+        pull = FakeGithub().pull | {"base": {"ref": "release"}}
+        with self.assertRaisesRegex(GateError, "base must be main"):
+            merge_pr(FakeGithub(pull=pull), POLICY, 12)
+
+    def test_failed_check_is_refused(self):
+        github = FakeGithub(checks=[check("CI"), check("Security", "failure")])
+        with self.assertRaisesRegex(GateError, "Security: completed/failure"):
+            merge_pr(github, POLICY, 12)
+        self.assertFalse(any(call[0] == "PUT" for call in github.calls))
+
+    def test_changed_head_cannot_be_merged_by_stale_sha(self):
+        pull = FakeGithub().pull | {"head": {"sha": "not-a-full-sha"}}
+        with self.assertRaisesRegex(GateError, "40-character"):
+            merge_pr(FakeGithub(pull=pull), POLICY, 12)
+
+    def test_unknown_policy_is_refused(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "repos.json"
+            path.write_text(json.dumps({"schemaVersion": 1, "repositories": {}}))
+            with self.assertRaisesRegex(GateError, "not allowlisted"):
+                load_policy(path, "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Lot 1 du plan d'industrialisation du choix de modèles.

## Ce que ça fait

Un dispatcher manuel unique, `deploy-coolify.yml`, devient le seul chemin vers la production. Il refuse :

- un service hors allowlist, ou un dépôt hors `FleetWorkAI/` ;
- un SHA qui n'est pas 40 caractères hexadécimaux, ou qui n'est pas la tête de `main` du bon dépôt ;
- un check requis manquant, en attente, en échec, ou rattaché à un autre SHA ;
- plus de cent checks, qu'il ne pourrait pas évaluer complètement.

Avant de toucher Coolify, il vérifie le nom, le dépôt et la branche de l'application, plus l'absence de doublon d'environnement par couple `(clé, is_preview)`. Il épingle ensuite `git_commit_sha` au SHA approuvé, relit ce pin, attend l'état terminal du déploiement, et exige que le commit déployé soit exactement celui approuvé, que l'application soit `running`, que son horodatage de redémarrage ait changé, et que le marqueur de démarrage apparaisse dans les journaux frais.

Les cibles d'un même service se déploient en séquence, et la concurrence `production-fleetwork` en `cancel-in-progress: false` sérialise toutes les productions, tous dépôts confondus.

## Correctif de sécurité inclus

Le workflow interpolait `${{ inputs.service }}` et `${{ inputs.sha }}` directement dans la ligne de commande. GitHub substitue ces expressions avant que le shell existe : une valeur d'entrée pouvait donc faire exécuter n'importe quoi au job qui détient les jetons Coolify et GitHub. Les deux entrées passent maintenant par l'environnement, où elles restent des données.

## Preuve

Les 19 tests du dispatcher passent sur un arbre extrait du commit, pas sur un dossier de travail. Le sabotage du contrôle « ce SHA est la tête de `main` » fait tomber un test, celui du contrôle « les checks requis sont verts » en fait tomber deux.

## Ce que ça ne fait pas

L'auto-déploiement Coolify reste actif tant qu'il n'est pas désactivé à la main, service par service. La protection de `main` et les checks requis côté GitHub restent à activer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)