### PR TITLE
feat(ops): gouverner les clés et la configuration LiteLLM depuis un desired state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,9 @@ jobs:
       - name: Unit tests
         run: python -m unittest discover tests -v
       - name: Compile
-        run: python -m py_compile scripts/deploy_coolify.py scripts/merge_checked_pr.py
+        run: >-
+          python -m py_compile
+          scripts/check_litellm_global_config.py
+          scripts/deploy_coolify.py
+          scripts/merge_checked_pr.py
+          scripts/reconcile_litellm_keys.py

--- a/.github/workflows/reconcile-litellm-keys.yml
+++ b/.github/workflows/reconcile-litellm-keys.yml
@@ -1,0 +1,161 @@
+name: Reconcile LiteLLM workload keys
+
+on:
+  workflow_dispatch:
+    inputs:
+      web_sha:
+        description: Full fleetwork-web SHA carrying the approved catalog at main
+        required: true
+        type: string
+      mode:
+        description: Report drift, apply policy, rotate one credential, or smoke every grant
+        required: true
+        default: check
+        type: choice
+        options:
+          - check
+          - apply
+          - rotate
+          - smoke
+      workload:
+        description: Workload to rotate when mode is rotate
+        required: true
+        default: runner
+        type: choice
+        options:
+          - runner
+          - coordinator
+          - catalog-probe
+          - spend-reader
+
+concurrency:
+  group: production-fleetwork
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    name: Validate and reconcile workload keys
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - name: Checkout deployment gate
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate reconcilers
+        run: python -m unittest discover tests -v
+      - name: Validate versioned LiteLLM global policy
+        run: >-
+          python scripts/check_litellm_global_config.py validate
+          --contract config/litellm-global-config.json
+          --repository-root .
+      - name: Gate the exact catalog SHA
+        env:
+          FLEETWORK_GITHUB_READ_TOKEN: ${{ secrets.FLEETWORK_GITHUB_READ_TOKEN }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          WEB_SHA: ${{ inputs.web_sha }}
+        run: >-
+          python scripts/deploy_coolify.py
+          --config config/coolify-services.json
+          --service web-worker
+          --sha "$WEB_SHA"
+          --dry-run
+      - name: Checkout the approved catalog
+        uses: actions/checkout@v4
+        with:
+          repository: FleetWorkAI/fleetwork-web
+          ref: ${{ inputs.web_sha }}
+          token: ${{ secrets.FLEETWORK_GITHUB_READ_TOKEN }}
+          persist-credentials: false
+          path: fleetwork-web
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: fleetwork-web/package-lock.json
+      - name: Verify immutable catalog
+        working-directory: fleetwork-web
+        run: |
+          npm ci
+          npm run catalog:check
+          npm run catalog:test
+      - name: Prepare read-only LiteLLM SSH gate
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.FLEETWORK_PRODUCTION_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.FLEETWORK_PRODUCTION_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SSH_KNOWN_HOSTS"
+          umask 077
+          mkdir -p "$RUNNER_TEMP/litellm-global-gate"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$RUNNER_TEMP/litellm-global-gate/identity"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$RUNNER_TEMP/litellm-global-gate/known_hosts"
+      - name: Gate source, host-mounted, and runtime LiteLLM policy
+        env:
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          FLEETWORK_PRODUCTION_SSH_HOST: ${{ secrets.FLEETWORK_PRODUCTION_SSH_HOST }}
+          FLEETWORK_PRODUCTION_SSH_PORT: ${{ secrets.FLEETWORK_PRODUCTION_SSH_PORT }}
+        run: >-
+          python scripts/check_litellm_global_config.py check-live
+          --contract config/litellm-global-config.json
+          --repository-root .
+          --ssh-identity "$RUNNER_TEMP/litellm-global-gate/identity"
+          --ssh-known-hosts "$RUNNER_TEMP/litellm-global-gate/known_hosts"
+      - name: Check workload-key drift
+        if: inputs.mode == 'check'
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_ADMIN_KEY: ${{ secrets.LITELLM_ADMIN_KEY }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          FLEETWORK_GITHUB_WRITE_TOKEN: ${{ secrets.FLEETWORK_GITHUB_WRITE_TOKEN }}
+        run: >-
+          python scripts/reconcile_litellm_keys.py check
+          --config config/litellm-workload-keys.json
+          --catalog fleetwork-web/config/llm/catalog.v1.json
+      - name: Apply workload keys and publish new secrets
+        if: inputs.mode == 'apply'
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_ADMIN_KEY: ${{ secrets.LITELLM_ADMIN_KEY }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          FLEETWORK_GITHUB_WRITE_TOKEN: ${{ secrets.FLEETWORK_GITHUB_WRITE_TOKEN }}
+        run: >-
+          python scripts/reconcile_litellm_keys.py apply
+          --config config/litellm-workload-keys.json
+          --catalog fleetwork-web/config/llm/catalog.v1.json
+      - name: Rotate one workload key and publish its replacement
+        if: inputs.mode == 'rotate'
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_ADMIN_KEY: ${{ secrets.LITELLM_ADMIN_KEY }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          FLEETWORK_GITHUB_WRITE_TOKEN: ${{ secrets.FLEETWORK_GITHUB_WRITE_TOKEN }}
+        run: >-
+          python scripts/reconcile_litellm_keys.py rotate
+          --workload "${{ inputs.workload }}"
+          --config config/litellm-workload-keys.json
+          --catalog fleetwork-web/config/llm/catalog.v1.json
+      - name: Smoke positive and negative workload grants
+        if: inputs.mode == 'smoke'
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_ADMIN_KEY: ${{ secrets.LITELLM_ADMIN_KEY }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          FLEETWORK_SMOKE_CATALOG_PROBE_KEY: ${{ secrets.LITELLM_PROBE_KEY }}
+        run: >-
+          python scripts/reconcile_litellm_keys.py smoke
+          --config config/litellm-workload-keys.json
+          --catalog fleetwork-web/config/llm/catalog.v1.json

--- a/.github/workflows/reconcile-litellm-models.yml
+++ b/.github/workflows/reconcile-litellm-models.yml
@@ -1,0 +1,147 @@
+name: Reconcile LiteLLM models
+
+on:
+  workflow_dispatch:
+    inputs:
+      web_sha:
+        description: Full fleetwork-web SHA currently at main
+        required: true
+        type: string
+      mode:
+        description: Read drift, apply desired state, or run workload smoke
+        required: true
+        default: check
+        type: choice
+        options:
+          - check
+          - apply
+          - smoke
+      adopt_existing:
+        description: One-time adoption of existing unmanaged public aliases
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: production-fleetwork
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    name: Validate and reconcile
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    steps:
+      - name: Check workflow inputs
+        env:
+          MODE: ${{ inputs.mode }}
+          ADOPT_EXISTING: ${{ inputs.adopt_existing }}
+        run: |
+          if [ "$ADOPT_EXISTING" = "true" ] && [ "$MODE" != "apply" ]; then
+            echo "::error::adopt_existing is valid only in apply mode"
+            exit 1
+          fi
+      - name: Checkout deployment gate
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate dispatcher
+        run: python -m unittest discover tests -v
+      - name: Validate versioned LiteLLM global policy
+        run: >-
+          python scripts/check_litellm_global_config.py validate
+          --contract config/litellm-global-config.json
+          --repository-root .
+      - name: Gate the exact web SHA
+        env:
+          FLEETWORK_GITHUB_READ_TOKEN: ${{ secrets.FLEETWORK_GITHUB_READ_TOKEN }}
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          WEB_SHA: ${{ inputs.web_sha }}
+        run: >-
+          python scripts/deploy_coolify.py
+          --config config/coolify-services.json
+          --service web-worker
+          --sha "$WEB_SHA"
+          --dry-run
+      - name: Checkout the approved catalog
+        uses: actions/checkout@v4
+        with:
+          repository: FleetWorkAI/fleetwork-web
+          ref: ${{ inputs.web_sha }}
+          token: ${{ secrets.FLEETWORK_GITHUB_READ_TOKEN }}
+          persist-credentials: false
+          path: fleetwork-web
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: fleetwork-web/package-lock.json
+      - name: Verify immutable catalog
+        working-directory: fleetwork-web
+        run: |
+          npm ci
+          npm run catalog:check
+          npm run catalog:test
+          npm run litellm:models:test
+      - name: Prepare read-only LiteLLM SSH gate
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.FLEETWORK_PRODUCTION_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.FLEETWORK_PRODUCTION_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SSH_KNOWN_HOSTS"
+          umask 077
+          mkdir -p "$RUNNER_TEMP/litellm-global-gate"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$RUNNER_TEMP/litellm-global-gate/identity"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$RUNNER_TEMP/litellm-global-gate/known_hosts"
+      - name: Gate source, host-mounted, and runtime LiteLLM policy
+        env:
+          COOLIFY_URL: ${{ secrets.COOLIFY_URL }}
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          FLEETWORK_PRODUCTION_SSH_HOST: ${{ secrets.FLEETWORK_PRODUCTION_SSH_HOST }}
+          FLEETWORK_PRODUCTION_SSH_PORT: ${{ secrets.FLEETWORK_PRODUCTION_SSH_PORT }}
+        run: >-
+          python scripts/check_litellm_global_config.py check-live
+          --contract config/litellm-global-config.json
+          --repository-root .
+          --ssh-identity "$RUNNER_TEMP/litellm-global-gate/identity"
+          --ssh-known-hosts "$RUNNER_TEMP/litellm-global-gate/known_hosts"
+      - name: Check model drift
+        if: inputs.mode == 'check'
+        working-directory: fleetwork-web
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_READ_KEY: ${{ secrets.LITELLM_READ_KEY }}
+        run: npm run litellm:models -- check
+      - name: Smoke with the workload probe
+        if: inputs.mode == 'smoke'
+        working-directory: fleetwork-web
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_READ_KEY: ${{ secrets.LITELLM_READ_KEY }}
+          LITELLM_PROBE_KEY: ${{ secrets.LITELLM_PROBE_KEY }}
+        run: npm run litellm:models -- smoke
+      - name: Apply managed models
+        if: inputs.mode == 'apply' && !inputs.adopt_existing
+        working-directory: fleetwork-web
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_ADMIN_KEY: ${{ secrets.LITELLM_ADMIN_KEY }}
+          LITELLM_PROBE_KEY: ${{ secrets.LITELLM_PROBE_KEY }}
+        run: npm run litellm:models -- apply
+      - name: Adopt and apply managed models
+        if: inputs.mode == 'apply' && inputs.adopt_existing
+        working-directory: fleetwork-web
+        env:
+          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+          LITELLM_ADMIN_KEY: ${{ secrets.LITELLM_ADMIN_KEY }}
+          LITELLM_PROBE_KEY: ${{ secrets.LITELLM_PROBE_KEY }}
+        run: npm run litellm:models -- apply --adopt-existing

--- a/config/litellm-global-config.json
+++ b/config/litellm-global-config.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "litellmVersion": "1.83.10",
+  "settingsSource": "config/litellm-global-settings.yaml",
+  "settingsSemanticDigest": "sha256:1c0e60bca81fe2b85f00191e895a2d94c0e515f9c405bead0aa086185810d927",
+  "coolify": {
+    "serviceUuid": "fnsbybwyqvg6ocuqzsqz3mzl",
+    "containerName": "litellm-fnsbybwyqvg6ocuqzsqz3mzl",
+    "composeSource": "./litellm-config.yaml",
+    "hostSource": "/data/coolify/services/fnsbybwyqvg6ocuqzsqz3mzl/litellm-config.yaml",
+    "containerTarget": "/app/config.yaml",
+    "sshUser": "debian"
+  }
+}

--- a/config/litellm-global-settings.yaml
+++ b/config/litellm-global-settings.yaml
@@ -1,0 +1,6 @@
+litellm_settings:
+  include_cost_in_streaming_usage: true
+  drop_params: false
+router_settings:
+  num_retries: 0
+  max_fallbacks: 0

--- a/config/litellm-workload-keys.json
+++ b/config/litellm-workload-keys.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "catalogVersion": "2026.08.05.4",
+  "litellmVersion": "1.83.10",
+  "workloads": [
+    {
+      "id": "runner",
+      "keyAlias": "fleet-runner",
+      "legacyAliases": [
+        "fleet-services"
+      ],
+      "models": [
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "gpt-5-nano",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "text-embedding-3-small"
+      ],
+      "allowedRoutes": [
+        "/chat/completions",
+        "/v1/chat/completions",
+        "/embeddings",
+        "/v1/embeddings",
+        "/models",
+        "/v1/models"
+      ],
+      "permissions": {},
+      "limits": {},
+      "sinks": [
+        {
+          "type": "coolify_env",
+          "applicationUuid": "yi0o3a7wwmc3bv5hhjx15ppi",
+          "key": "LITELLM_API_KEY",
+          "isPreview": false
+        }
+      ]
+    },
+    {
+      "id": "coordinator",
+      "keyAlias": "fleet-coordinator",
+      "legacyAliases": [],
+      "models": [
+        "gpt-5-nano"
+      ],
+      "allowedRoutes": [
+        "/chat/completions",
+        "/v1/chat/completions"
+      ],
+      "permissions": {},
+      "limits": {},
+      "sinks": [
+        {
+          "type": "coolify_env",
+          "applicationUuid": "ryhnzym3sqnv34qa7sh9i4ol",
+          "key": "LITELLM_API_KEY",
+          "isPreview": false
+        }
+      ]
+    },
+    {
+      "id": "catalog-probe",
+      "keyAlias": "fleet-catalog-probe",
+      "legacyAliases": [],
+      "models": [
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "gpt-5-nano",
+        "gpt-4o",
+        "gpt-4o-mini"
+      ],
+      "allowedRoutes": [
+        "/chat/completions",
+        "/v1/chat/completions",
+        "/models",
+        "/v1/models"
+      ],
+      "permissions": {},
+      "limits": {
+        "rpm": 6,
+        "tpm": 100000,
+        "maxParallelRequests": 1,
+        "maxBudgetUsd": 1,
+        "budgetDuration": "30d"
+      },
+      "sinks": [
+        {
+          "type": "github_environment_secret",
+          "repository": "FleetWorkAI/.github",
+          "environment": "production",
+          "key": "LITELLM_PROBE_KEY",
+          "fingerprintKey": "LITELLM_PROBE_KEY_SHA256"
+        }
+      ]
+    },
+    {
+      "id": "spend-reader",
+      "keyAlias": "fleet-spend-reader",
+      "legacyAliases": [],
+      "models": [],
+      "allowedRoutes": [
+        "/spend/logs"
+      ],
+      "permissions": {},
+      "limits": {
+        "rpm": 60,
+        "maxParallelRequests": 4
+      },
+      "sinks": [
+        {
+          "type": "coolify_env",
+          "applicationUuid": "yi0o3a7wwmc3bv5hhjx15ppi",
+          "key": "LITELLM_SPEND_API_KEY",
+          "isPreview": false
+        }
+      ]
+    }
+  ]
+}

--- a/docs/runbooks/litellm-workload-keys.md
+++ b/docs/runbooks/litellm-workload-keys.md
@@ -1,0 +1,159 @@
+# LiteLLM workload keys
+
+## Contract
+
+FleetWork uses one virtual key per server workload, never per browser or per company:
+
+| Alias | Models | Routes | Secret sink |
+| --- | --- | --- | --- |
+| `fleet-runner` | Five executable chat aliases plus the embedding route | Chat, embeddings, model listing | Runner `LITELLM_API_KEY` |
+| `fleet-coordinator` | `gpt-5-nano` | Chat only | Coordinator `LITELLM_API_KEY` |
+| `fleet-catalog-probe` | Five executable chat aliases | Chat and model listing | GitHub `production/LITELLM_PROBE_KEY` |
+| `fleet-spend-reader` | None | `/spend/logs` only | Runner `LITELLM_SPEND_API_KEY` |
+
+The spend key uses only the exact `allowed_routes: ["/spend/logs"]` grant. Do not set
+`permissions.get_spend_routes`: LiteLLM 1.83.10 gates that key-generation field behind Enterprise,
+while its pinned route checker independently accepts an explicitly allowed route. This OSS-safe
+contract must still receive a real authenticated `/spend/logs` HTTP 200 smoke before rollout.
+The probe has a 1 USD rolling budget, one parallel request, and low RPM/TPM limits. Empty
+`allowed_routes` is forbidden because LiteLLM interprets it as unrestricted.
+
+Runner and coordinator rate limits remain unset until production percentiles and burst requirements
+are measured. Inventing a cap during a credential split would turn governance into an outage risk.
+Their catalog cost/output limits still apply to each run.
+
+The desired state is [litellm-workload-keys.json](../../config/litellm-workload-keys.json). The
+reconciler validates its model sets against the approved web catalog before contacting production.
+
+## Global configuration gate
+
+The versioned global policy is
+[litellm-global-settings.yaml](../../config/litellm-global-settings.yaml). It requires all four
+settings together:
+
+```yaml
+litellm_settings:
+  include_cost_in_streaming_usage: true
+  drop_params: false
+router_settings:
+  num_retries: 0
+  max_fallbacks: 0
+```
+
+The pinned digest in
+[litellm-global-config.json](../../config/litellm-global-config.json) is a SHA-256 of canonical JSON
+for those four scalars. YAML order, comments and whitespace do not change it. A changed value,
+missing value, duplicate governed key or stale digest fails closed.
+
+Before every workload-key or model `check`, `apply`, `rotate` or `smoke`, the workflow performs a
+read-only three-copy gate:
+
+1. Validate the versioned source and semantic digest.
+2. Verify through the Coolify API that service `fnsbybwyqvg6ocuqzsqz3mzl` still binds the declared
+   host file to `/app/config.yaml` in the declared container.
+3. Read the host bind source and `/app/config.yaml` inside the running container over SSH as
+   `debian`, compare the governed settings to source, then require the two live files to be byte
+   identical.
+
+The controller parses only governed scalar values. It never prints either production file, API
+response bodies, SSH stderr or secret values. Its successful output contains only the service UUID,
+the semantic policy digest and the three checked copy labels.
+
+The protected `production` environment must provide
+`FLEETWORK_PRODUCTION_SSH_HOST`, `FLEETWORK_PRODUCTION_SSH_PORT`,
+`FLEETWORK_PRODUCTION_SSH_PRIVATE_KEY` and a pinned
+`FLEETWORK_PRODUCTION_SSH_KNOWN_HOSTS`, in addition to the existing Coolify credentials. Missing SSH
+material, host-key mismatch, password-requiring `sudo`, unreadable file, mount drift, policy drift or
+host/runtime byte drift stops the workflow before any LiteLLM mutation or smoke.
+
+The gate never edits production. Updating the live global file and restarting LiteLLM remain a
+separate, explicitly approved production operation. Do not paste or export the full production
+configuration into a PR, workflow log or issue.
+
+## Safe operation
+
+Only run `.github/workflows/reconcile-litellm-keys.yml`. It shares the
+`production-fleetwork` concurrency group with every deployment and model reconciliation.
+
+1. This first OpenRouter cutover is intentionally breaking: `gpt-4o-mini` cannot execute the
+   runner's tool contract on its available ZDR route. Pause fresh producers and drain legacy jobs
+   and pauses with the old runner before changing LiteLLM or deploying catalog `2026.08.05.3`.
+2. Run the key workflow in `check` and review its safe report. The global configuration gate must be
+   `current`; a failure blocks every later step. Do not bypass it by invoking a reconciler locally
+   with production credentials.
+3. Bootstrap workload keys before models. Run `apply` through the protected `production`
+   environment, then run `check` again. Every workload must be `current`. Authorizing new aliases
+   before they exist is additive and gives the model reconciler its required
+   `production/LITELLM_PROBE_KEY`.
+4. Run the model reconciler in `apply`, then `smoke`. The explicitly inactive managed
+   `gpt-4o-mini` deployment is removed only after all five replacement canaries and public aliases
+   pass. Its transactional rollback restores the removed route if that apply fails. Then run this
+   workload-key workflow in `smoke`: runner chat/embedding, coordinator chat, catalog listing and
+   spend lookup must return 2xx. Every negative uses the exact request that another least-privilege
+   key proves valid; routes or models outside the tested grant must return exactly HTTP 403. A 400,
+   401, 404, 429 or 5xx does not prove authorization and fails the gate.
+5. Deploy the runner, coordinator, then web/worker in the same maintenance window. This release
+   does not claim an accepted previous catalog version because its executable set changed.
+6. Trigger a real coordinator summary and verify its key attribution, model, cost and health.
+7. Enable `REQUIRE_MODEL_CATALOG_VERSION=true` only after those proofs, restart the affected
+   consumers, and run the final application smoke. Fresh routine jobs carry the full contract too.
+   New HITL snapshots preserve their model and provenance; older snapshots fail closed.
+
+If key bootstrap fails, do not run model reconciliation. If model reconciliation fails, keep the
+applications paused and do not deploy consumers. If an application deployment fails after the
+breaking model cutover, keep maintenance mode active, restore the previous catalog and its routes
+first, verify them, then roll consumers back in reverse order. Never restart an old runner against
+an incompatible executable set.
+
+For later additive releases, the normal expand/contract order remains consumer `{current,
+previous}`, producer `current`, drain, then removal of `previous`. Never list a previous version in a
+lock unless every alias executable in that version still has an executable compatibility route.
+
+The one-time alias `fleet-services` is adopted in place and renamed to `fleet-runner`. Its secret is
+not rotated merely to rename it.
+
+## Failure behavior
+
+- Duplicate aliases or managed metadata identities stop before mutation. A managed key is recovered
+  by its metadata even if its alias was changed outside the reconciler.
+- Existing keys are updated in place and snapshot-restored when later work fails.
+- A newly generated key is sent to its sink in memory. It is never printed, placed in an argument,
+  written to disk, or exposed through a workflow output.
+- A failed or ambiguous creation is rediscovered by alias and revoked. Failure to prove that cleanup
+  happened is an explicit incident.
+- Every sink identity and read path is preflighted before key mutation. Write permission is proved
+  only by the subsequent write plus read-back/fingerprint verification. A failed or ambiguous sink write keeps
+  an identified `rotation_candidate` active, so a value that may already have reached a workload
+  never dies. A later `rotate` run recognizes a fully published candidate by every sink fingerprint
+  and finishes the switch. A partially published or uninspectable candidate blocks creation of any
+  additional candidate until sink recovery or manual review. Five pending candidates remains a hard
+  manual-review boundary.
+- Coolify environment rows are listed first. Duplicate rows fail closed; zero creates; one patches;
+  the value is reread and compared without logging.
+- GitHub secrets are passed to `gh secret set` on stdin. A separate environment variable stores only
+  the SHA-256 fingerprint. `check` also compares GitHub update timestamps: a secret changed after
+  its fingerprint is stale. GitHub remains write-only, so an interrupted secret/fingerprint pair is
+  reported as ambiguous and its candidate stays active until a later successful rotation.
+- Existing Coolify values are hashed in memory and compared with LiteLLM's immutable key identifier.
+  A mismatch is reported as `sink` drift and `apply` refuses until an explicit rotation is approved.
+
+Never retry a failed `apply` blindly. Run `check`, inspect the four aliases in LiteLLM, and resolve an
+`ambiguous and cleanup could not be proven` incident before continuing.
+
+## Rotation
+
+Routine rotation is additive and implemented by the protected workflow:
+
+1. Run `check` and inspect any `rotation: pending` marker.
+2. Dispatch `rotate` for exactly one selected workload. The replacement uses a distinct candidate
+   alias and metadata, so an interrupted run remains recoverable.
+3. The command publishes and verifies every sink before it revokes the previous credential. A
+   previously published candidate is completed without generating another key.
+4. Run `check` again, then smoke and restart only the affected workload if its platform requires it.
+5. Confirm spend attribution under the canonical workload alias.
+
+Do not use delete-then-create. It creates an outage and loses the rollback credential.
+
+For a multi-sink workload, one successful sink followed by another failing sink is a partial
+publication. Both old and candidate keys remain active. The next rotation refuses to mint a third
+key until every sink is recovered or the candidate is reviewed manually.

--- a/scripts/check_litellm_global_config.py
+++ b/scripts/check_litellm_global_config.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+"""Fail-closed drift gate for the LiteLLM config mounted by Coolify."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__:
+    from scripts.reconcile_litellm_keys import JsonClient, ReconcileError
+else:
+    from reconcile_litellm_keys import JsonClient, ReconcileError
+
+
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,63}$")
+HOST_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.:-]{0,252}$")
+REQUIRED_SETTINGS = {
+    "litellm_settings": {
+        "include_cost_in_streaming_usage": True,
+        "drop_params": False,
+    },
+    "router_settings": {
+        "num_retries": 0,
+        "max_fallbacks": 0,
+    },
+}
+
+
+@dataclass(frozen=True)
+class MountContract:
+    service_uuid: str
+    container_name: str
+    compose_source: str
+    host_source: str
+    container_target: str
+    ssh_user: str
+
+
+@dataclass(frozen=True)
+class GlobalConfigContract:
+    source: Path
+    semantic_digest: str
+    mount: MountContract
+
+
+def _scalar(value: str) -> bool | int | float | str | None:
+    raw = value.strip()
+    if raw.lower() == "true":
+        return True
+    if raw.lower() == "false":
+        return False
+    if re.fullmatch(r"-?(?:0|[1-9][0-9]*)", raw):
+        return int(raw)
+    if re.fullmatch(r"-?(?:[0-9]+\.[0-9]*|[0-9]*\.[0-9]+)", raw):
+        return float(raw)
+    if raw.lower() in ("null", "~"):
+        return None
+    if raw.startswith(('"', "'")):
+        if len(raw) < 2 or raw[-1] != raw[0]:
+            raise ReconcileError("invalid quoted YAML scalar")
+        if raw[0] == '"':
+            try:
+                value = json.loads(raw)
+            except json.JSONDecodeError as error:
+                raise ReconcileError("invalid quoted YAML scalar") from error
+            if not isinstance(value, str):
+                raise ReconcileError("invalid quoted YAML scalar")
+            return value
+        return raw[1:-1].replace("''", "'")
+    if raw.startswith(("&", "*", "!", "|", ">")):
+        raise ReconcileError("unsupported ambiguous YAML value")
+    if not raw or raw[0] in ",[]{}#%@`":
+        raise ReconcileError("invalid plain YAML scalar")
+    if raw[0] in "-?:" and (len(raw) == 1 or raw[1].isspace()):
+        raise ReconcileError("invalid plain YAML scalar")
+    if re.search(r":(?:\s|$)", raw):
+        raise ReconcileError("invalid plain YAML scalar")
+    return raw
+
+
+def _without_yaml_comment(value: str) -> str:
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if quote == '"' and character == "\\":
+            escaped = True
+            index += 1
+            continue
+        if character in ("'", '"'):
+            if quote is None:
+                quote = character
+            elif quote == character:
+                if quote == "'" and index + 1 < len(value) and value[index + 1] == "'":
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+        if character == "#" and quote is None and (
+            index == 0 or value[index - 1].isspace()
+        ):
+            return value[:index].rstrip()
+        index += 1
+    if quote is not None:
+        raise ReconcileError("unterminated quoted YAML scalar")
+    return value.rstrip()
+
+
+def _mapping_pair(value: str) -> tuple[str, str] | None:
+    quote: str | None = None
+    escaped = False
+    depth = 0
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if quote == '"' and character == "\\":
+            escaped = True
+            index += 1
+            continue
+        if character in ("'", '"'):
+            if quote is None:
+                quote = character
+            elif quote == character:
+                if quote == "'" and index + 1 < len(value) and value[index + 1] == "'":
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+        if quote is not None:
+            index += 1
+            continue
+        if character in "[{":
+            depth += 1
+        elif character in "]}":
+            depth -= 1
+            if depth < 0:
+                raise ReconcileError("invalid YAML flow structure")
+        elif character == ":" and depth == 0 and (
+            index + 1 == len(value) or value[index + 1].isspace()
+        ):
+            raw_key = value[:index].strip()
+            if not raw_key:
+                raise ReconcileError("empty YAML mapping key")
+            key = _scalar(raw_key)
+            if not isinstance(key, str):
+                raise ReconcileError("YAML mapping keys must be strings")
+            return key, value[index + 1 :].strip()
+        index += 1
+    if quote is not None or depth != 0:
+        raise ReconcileError("invalid YAML structure")
+    return None
+
+
+class _FlowParser:
+    def __init__(self, value: str):
+        self.value = value
+        self.index = 0
+
+    def parse(self) -> Any:
+        result = self._value()
+        self._space()
+        if self.index != len(self.value):
+            raise ReconcileError("invalid trailing YAML flow content")
+        return result
+
+    def _space(self) -> None:
+        while self.index < len(self.value) and self.value[self.index].isspace():
+            self.index += 1
+
+    def _value(self) -> Any:
+        self._space()
+        if self.index >= len(self.value):
+            raise ReconcileError("missing YAML flow value")
+        character = self.value[self.index]
+        if character == "{":
+            return self._mapping()
+        if character == "[":
+            return self._sequence()
+        if character in ("'", '"'):
+            return self._quoted()
+        start = self.index
+        while self.index < len(self.value) and self.value[self.index] not in ",]}":
+            self.index += 1
+        raw = self.value[start : self.index].strip()
+        if not raw:
+            raise ReconcileError("missing YAML flow value")
+        return _scalar(raw)
+
+    def _quoted(self) -> str:
+        quote = self.value[self.index]
+        start = self.index
+        self.index += 1
+        while self.index < len(self.value):
+            character = self.value[self.index]
+            self.index += 1
+            if quote == '"' and character == "\\":
+                if self.index >= len(self.value):
+                    break
+                self.index += 1
+                continue
+            if character == quote:
+                if quote == "'" and self.index < len(self.value) and self.value[self.index] == "'":
+                    self.index += 1
+                    continue
+                value = _scalar(self.value[start : self.index])
+                if not isinstance(value, str):
+                    raise ReconcileError("invalid quoted YAML scalar")
+                return value
+        raise ReconcileError("unterminated quoted YAML scalar")
+
+    def _mapping(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        self.index += 1
+        self._space()
+        if self.index < len(self.value) and self.value[self.index] == "}":
+            self.index += 1
+            return result
+        while True:
+            key = self._flow_key()
+            self._space()
+            if self.index >= len(self.value) or self.value[self.index] != ":":
+                raise ReconcileError("invalid YAML flow mapping")
+            self.index += 1
+            if key in result:
+                raise ReconcileError("duplicate YAML mapping key")
+            result[key] = self._value()
+            self._space()
+            if self.index >= len(self.value):
+                raise ReconcileError("unterminated YAML flow mapping")
+            separator = self.value[self.index]
+            self.index += 1
+            if separator == "}":
+                return result
+            if separator != ",":
+                raise ReconcileError("invalid YAML flow mapping")
+
+    def _flow_key(self) -> str:
+        self._space()
+        if self.index < len(self.value) and self.value[self.index] in ("'", '"'):
+            return self._quoted()
+        start = self.index
+        while self.index < len(self.value) and self.value[self.index] != ":":
+            if self.value[self.index] in "{},[]":
+                raise ReconcileError("invalid YAML flow mapping key")
+            self.index += 1
+        raw = self.value[start : self.index].strip()
+        if not raw:
+            raise ReconcileError("empty YAML mapping key")
+        key = _scalar(raw)
+        if not isinstance(key, str):
+            raise ReconcileError("YAML mapping keys must be strings")
+        return key
+
+    def _sequence(self) -> list[Any]:
+        result: list[Any] = []
+        self.index += 1
+        self._space()
+        if self.index < len(self.value) and self.value[self.index] == "]":
+            self.index += 1
+            return result
+        while True:
+            result.append(self._value())
+            self._space()
+            if self.index >= len(self.value):
+                raise ReconcileError("unterminated YAML flow sequence")
+            separator = self.value[self.index]
+            self.index += 1
+            if separator == "]":
+                return result
+            if separator != ",":
+                raise ReconcileError("invalid YAML flow sequence")
+
+
+class _StrictYamlParser:
+    def __init__(self, text: str):
+        self.lines: list[tuple[int, str]] = []
+        if text.startswith("\ufeff"):
+            raise ReconcileError("YAML byte-order marks are not supported")
+        for raw_line in text.splitlines():
+            if "\t" in raw_line[: len(raw_line) - len(raw_line.lstrip())]:
+                raise ReconcileError("YAML indentation must use spaces")
+            content = _without_yaml_comment(raw_line).rstrip()
+            if not content.strip():
+                continue
+            indent = len(content) - len(content.lstrip(" "))
+            stripped = content[indent:]
+            if stripped.startswith("%") or stripped in ("---", "..."):
+                raise ReconcileError("multiple or directed YAML documents are not supported")
+            self.lines.append((indent, stripped))
+
+    def parse(self) -> Any:
+        if not self.lines:
+            raise ReconcileError("empty YAML document")
+        if self.lines[0][0] != 0:
+            raise ReconcileError("YAML root must not be indented")
+        result, index = self._node(0, 0)
+        if index != len(self.lines):
+            raise ReconcileError("invalid YAML indentation")
+        return result
+
+    def _node(self, index: int, indent: int) -> tuple[Any, int]:
+        if self.lines[index][0] != indent:
+            raise ReconcileError("invalid YAML indentation")
+        if self.lines[index][1] == "-" or self.lines[index][1].startswith("- "):
+            return self._sequence(index, indent)
+        return self._mapping(index, indent)
+
+    def _nested(self, index: int, parent_indent: int) -> tuple[Any, int]:
+        if index >= len(self.lines) or self.lines[index][0] <= parent_indent:
+            return None, index
+        return self._node(index, self.lines[index][0])
+
+    def _mapping(
+        self,
+        index: int,
+        indent: int,
+        initial: tuple[str, str] | None = None,
+    ) -> tuple[dict[str, Any], int]:
+        result: dict[str, Any] = {}
+        if initial is not None:
+            index = self._mapping_value(result, initial, index, indent)
+        while index < len(self.lines) and self.lines[index][0] == indent:
+            content = self.lines[index][1]
+            if content == "-" or content.startswith("- "):
+                break
+            pair = _mapping_pair(content)
+            if pair is None:
+                raise ReconcileError("invalid YAML mapping entry")
+            index = self._mapping_value(result, pair, index + 1, indent)
+        return result, index
+
+    def _mapping_value(
+        self,
+        result: dict[str, Any],
+        pair: tuple[str, str],
+        next_index: int,
+        indent: int,
+    ) -> int:
+        key, raw_value = pair
+        if key in result:
+            raise ReconcileError("duplicate YAML mapping key")
+        if raw_value:
+            result[key] = self._inline_value(raw_value)
+            return next_index
+        result[key], next_index = self._nested(next_index, indent)
+        return next_index
+
+    def _sequence(self, index: int, indent: int) -> tuple[list[Any], int]:
+        result: list[Any] = []
+        while index < len(self.lines) and self.lines[index][0] == indent:
+            content = self.lines[index][1]
+            if content != "-" and not content.startswith("- "):
+                break
+            raw_value = content[1:].strip()
+            index += 1
+            if not raw_value:
+                value, index = self._nested(index, indent)
+                if value is None:
+                    raise ReconcileError("missing YAML sequence value")
+                result.append(value)
+                continue
+            pair = _mapping_pair(raw_value)
+            if pair is not None:
+                child_indent = indent + 2
+                value, index = self._mapping(index, child_indent, pair)
+                result.append(value)
+                continue
+            result.append(self._inline_value(raw_value))
+            if index < len(self.lines) and self.lines[index][0] > indent:
+                raise ReconcileError("scalar YAML sequence item cannot have children")
+        return result, index
+
+    @staticmethod
+    def _inline_value(value: str) -> Any:
+        if value.startswith(("{", "[")):
+            return _FlowParser(value).parse()
+        return _scalar(value)
+
+
+def _load_yaml(text: str, purpose: str) -> Any:
+    try:
+        return _StrictYamlParser(text).parse()
+    except ReconcileError as error:
+        raise ReconcileError(f"invalid {purpose} YAML: {error}") from error
+
+
+def governed_settings(text: str) -> dict[str, dict[str, bool | int | str]]:
+    """Parse YAML strictly, then return only the four non-secret policy values."""
+    document = _load_yaml(text, "LiteLLM config")
+    if not isinstance(document, dict):
+        raise ReconcileError("LiteLLM config YAML root must be a mapping")
+    found: dict[str, dict[str, bool | int | str]] = {}
+    for section, required in REQUIRED_SETTINGS.items():
+        raw_section = document.get(section)
+        if raw_section is None:
+            found[section] = {}
+            continue
+        if not isinstance(raw_section, dict):
+            raise ReconcileError(f"{section} must be a YAML mapping")
+        found[section] = {}
+        for key, expected in required.items():
+            if key not in raw_section:
+                continue
+            value = raw_section[key]
+            if type(value) is not type(expected):
+                raise ReconcileError(f"{section}.{key} has an invalid YAML type")
+            found[section][key] = value
+    return found
+
+
+def settings_digest(settings: dict[str, dict[str, Any]]) -> str:
+    """Hash canonical JSON so YAML ordering, comments, and whitespace do not matter."""
+    canonical = json.dumps(settings, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def _required_string(row: dict[str, Any], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value:
+        raise ReconcileError(f"global config contract {key} must be a non-empty string")
+    return value
+
+
+def load_contract(path: Path, repository_root: Path) -> GlobalConfigContract:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReconcileError(f"cannot read global config contract {path}") from error
+    if not isinstance(raw, dict) or raw.get("schemaVersion") != 1:
+        raise ReconcileError("unsupported global config contract schema")
+    if raw.get("litellmVersion") != "1.83.10":
+        raise ReconcileError("global config contract must target LiteLLM 1.83.10")
+    source_ref = _required_string(raw, "settingsSource")
+    source = (repository_root / source_ref).resolve()
+    root = repository_root.resolve()
+    if source != root and root not in source.parents:
+        raise ReconcileError("global settings source escapes the repository")
+    expected_digest = _required_string(raw, "settingsSemanticDigest")
+    if not DIGEST_RE.fullmatch(expected_digest):
+        raise ReconcileError("global settings digest must be sha256")
+    try:
+        desired = governed_settings(source.read_text())
+    except OSError as error:
+        raise ReconcileError(f"cannot read global settings source {source}") from error
+    if desired != REQUIRED_SETTINGS:
+        raise ReconcileError("global settings source does not match the mandatory policy")
+    if settings_digest(desired) != expected_digest:
+        raise ReconcileError("global settings digest is stale")
+
+    coolify = raw.get("coolify")
+    if not isinstance(coolify, dict):
+        raise ReconcileError("global config contract coolify must be an object")
+    mount = MountContract(
+        service_uuid=_required_string(coolify, "serviceUuid"),
+        container_name=_required_string(coolify, "containerName"),
+        compose_source=_required_string(coolify, "composeSource"),
+        host_source=_required_string(coolify, "hostSource"),
+        container_target=_required_string(coolify, "containerTarget"),
+        ssh_user=_required_string(coolify, "sshUser"),
+    )
+    if not all(
+        IDENTIFIER_RE.fullmatch(value)
+        for value in (
+            mount.service_uuid,
+            mount.container_name,
+            mount.ssh_user,
+        )
+    ):
+        raise ReconcileError("global config contract contains an unsafe identifier")
+    expected_host = f"/data/coolify/services/{mount.service_uuid}/litellm-config.yaml"
+    if (
+        mount.compose_source != "./litellm-config.yaml"
+        or mount.host_source != expected_host
+        or mount.container_target != "/app/config.yaml"
+        or mount.ssh_user != "debian"
+    ):
+        raise ReconcileError("global config contract contains an unsafe mount or SSH target")
+    return GlobalConfigContract(source, expected_digest, mount)
+
+
+def check_actual_config(contract: GlobalConfigContract, actual_text: str) -> dict[str, str]:
+    actual = governed_settings(actual_text)
+    drift = [
+        f"{section}.{key}"
+        for section, required in REQUIRED_SETTINGS.items()
+        for key, expected in required.items()
+        if actual.get(section, {}).get(key) != expected
+    ]
+    if drift:
+        raise ReconcileError("LiteLLM global config drift: " + ", ".join(drift))
+    digest = settings_digest(actual)
+    if digest != contract.semantic_digest:
+        raise ReconcileError("LiteLLM global config digest mismatch")
+    return {"status": "current", "settingsSemanticDigest": digest}
+
+
+def check_coolify_mount(contract: GlobalConfigContract, coolify: JsonClient) -> dict[str, str]:
+    mount = contract.mount
+    service = coolify.get(f"/services/{mount.service_uuid}")
+    if not isinstance(service, dict):
+        raise ReconcileError("Coolify returned an invalid LiteLLM service")
+    if service.get("uuid") != mount.service_uuid:
+        raise ReconcileError("Coolify LiteLLM service UUID drift")
+    raw = service.get("docker_compose_raw")
+    rendered = service.get("docker_compose")
+    if not isinstance(raw, str) or not isinstance(rendered, str):
+        raise ReconcileError("Coolify did not return both LiteLLM compose documents")
+    raw_services = _compose_services(raw, "raw Coolify compose")
+    rendered_services = _compose_services(rendered, "rendered Coolify compose")
+    raw_litellm = raw_services.get("litellm")
+    rendered_litellm = rendered_services.get("litellm")
+    if not isinstance(raw_litellm, dict) or not isinstance(rendered_litellm, dict):
+        raise ReconcileError("Coolify LiteLLM compose service drift")
+    if rendered_litellm.get("container_name") != mount.container_name:
+        raise ReconcileError("Coolify LiteLLM container identity drift")
+    if not _has_bind_mount(
+        raw_litellm.get("volumes"), mount.compose_source, mount.container_target
+    ):
+        raise ReconcileError("Coolify LiteLLM source mount drift")
+    if not _has_bind_mount(
+        rendered_litellm.get("volumes"), mount.host_source, mount.container_target
+    ):
+        raise ReconcileError("Coolify LiteLLM rendered mount drift")
+    return {"status": "current", "serviceUuid": mount.service_uuid}
+
+
+def _compose_services(text: str, purpose: str) -> dict[str, Any]:
+    document = _load_yaml(text, purpose)
+    if not isinstance(document, dict):
+        raise ReconcileError(f"{purpose} root must be a mapping")
+    services = document.get("services")
+    if not isinstance(services, dict) or not services:
+        raise ReconcileError(f"{purpose} services must be a non-empty mapping")
+    if not all(isinstance(name, str) and isinstance(value, dict) for name, value in services.items()):
+        raise ReconcileError(f"{purpose} contains an invalid service")
+    return services
+
+
+def _has_bind_mount(volumes: Any, source: str, target: str) -> bool:
+    if not isinstance(volumes, list):
+        return False
+    target_mounts: list[bool] = []
+    for volume in volumes:
+        if isinstance(volume, dict):
+            if volume.get("target") == target:
+                target_mounts.append(
+                    volume.get("type") == "bind" and volume.get("source") == source
+                )
+            continue
+        if not isinstance(volume, str):
+            continue
+        parts = volume.split(":")
+        if len(parts) in (2, 3) and parts[1] == target:
+            target_mounts.append(parts[0] == source)
+    return target_mounts == [True]
+
+
+def _read_remote_text(
+    contract: GlobalConfigContract,
+    host: str,
+    port: int,
+    identity_file: Path,
+    known_hosts_file: Path,
+    remote_command: list[str],
+    target_name: str,
+) -> str:
+    if not HOST_RE.fullmatch(host) or not 1 <= port <= 65535:
+        raise ReconcileError("invalid LiteLLM config SSH endpoint")
+    if not identity_file.is_file() or not known_hosts_file.is_file():
+        raise ReconcileError("LiteLLM config SSH identity and known_hosts are required")
+    mount = contract.mount
+    command = [
+        "ssh",
+        "-F",
+        "/dev/null",
+        "-i",
+        str(identity_file),
+        "-p",
+        str(port),
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "IdentitiesOnly=yes",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        f"UserKnownHostsFile={known_hosts_file}",
+        f"{mount.ssh_user}@{host}",
+        *remote_command,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ReconcileError(f"could not read the {target_name} LiteLLM config over SSH") from error
+    try:
+        return result.stdout.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ReconcileError(f"{target_name} LiteLLM config is not UTF-8") from error
+
+
+def read_remote_configs(
+    contract: GlobalConfigContract,
+    host: str,
+    port: int,
+    identity_file: Path,
+    known_hosts_file: Path,
+) -> tuple[str, str]:
+    """Read the host bind source and the runtime target without logging either file."""
+    mount = contract.mount
+    mounted = _read_remote_text(
+        contract,
+        host,
+        port,
+        identity_file,
+        known_hosts_file,
+        ["sudo", "-n", "cat", mount.host_source],
+        "host-mounted",
+    )
+    runtime = _read_remote_text(
+        contract,
+        host,
+        port,
+        identity_file,
+        known_hosts_file,
+        [
+            "sudo",
+            "-n",
+            "docker",
+            "exec",
+            mount.container_name,
+            "cat",
+            mount.container_target,
+        ],
+        "runtime",
+    )
+    return mounted, runtime
+
+
+def check_remote_configs(
+    contract: GlobalConfigContract,
+    mounted_text: str,
+    runtime_text: str,
+) -> dict[str, str]:
+    """Compare the source policy with both live copies, then prove the bind is exact."""
+    mounted = check_actual_config(contract, mounted_text)
+    runtime = check_actual_config(contract, runtime_text)
+    mounted_bytes = hashlib.sha256(mounted_text.encode("utf-8")).digest()
+    runtime_bytes = hashlib.sha256(runtime_text.encode("utf-8")).digest()
+    if mounted_bytes != runtime_bytes:
+        raise ReconcileError("LiteLLM host-mounted and runtime config files differ")
+    if mounted["settingsSemanticDigest"] != runtime["settingsSemanticDigest"]:
+        raise ReconcileError("LiteLLM host-mounted and runtime policy digests differ")
+    return {
+        "status": "current",
+        "settingsSemanticDigest": mounted["settingsSemanticDigest"],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("validate", "check", "check-live"))
+    parser.add_argument("--contract", type=Path, required=True)
+    parser.add_argument("--repository-root", type=Path, default=Path.cwd())
+    parser.add_argument("--actual", default="-")
+    parser.add_argument("--ssh-identity", type=Path)
+    parser.add_argument("--ssh-known-hosts", type=Path)
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    contract = load_contract(args.contract, args.repository_root)
+    if args.mode == "validate":
+        return {"status": "valid", "settingsSemanticDigest": contract.semantic_digest}
+    if args.mode == "check":
+        actual = sys.stdin.read() if args.actual == "-" else Path(args.actual).read_text()
+        return check_actual_config(contract, actual)
+
+    coolify_url = os.environ.get("COOLIFY_URL", "").rstrip("/")
+    coolify_token = os.environ.get("COOLIFY_API_TOKEN", "")
+    host = os.environ.get("FLEETWORK_PRODUCTION_SSH_HOST", "")
+    port_raw = os.environ.get("FLEETWORK_PRODUCTION_SSH_PORT", "")
+    if not coolify_url.startswith("https://") or not coolify_token:
+        raise ReconcileError("COOLIFY_URL and COOLIFY_API_TOKEN are required")
+    try:
+        port = int(port_raw)
+    except ValueError as error:
+        raise ReconcileError("FLEETWORK_PRODUCTION_SSH_PORT must be an integer") from error
+    if args.ssh_identity is None or args.ssh_known_hosts is None:
+        raise ReconcileError("check-live requires SSH identity and known_hosts paths")
+    coolify = JsonClient(
+        f"{coolify_url}/api/v1", coolify_token, "fleetwork-litellm-global-config/1"
+    )
+    mount_report = check_coolify_mount(contract, coolify)
+    mounted, runtime = read_remote_configs(
+        contract, host, port, args.ssh_identity, args.ssh_known_hosts
+    )
+    config_report = check_remote_configs(contract, mounted, runtime)
+    return {
+        "status": "current",
+        "serviceUuid": mount_report["serviceUuid"],
+        "settingsSemanticDigest": config_report["settingsSemanticDigest"],
+        "checkedCopies": ["versioned-source", "host-mounted", "runtime"],
+    }
+
+
+def main() -> int:
+    try:
+        result = run(build_parser().parse_args())
+    except (OSError, ReconcileError) as error:
+        print(f"LiteLLM global config gate refused: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_litellm_keys.py
+++ b/scripts/reconcile_litellm_keys.py
@@ -1,0 +1,1305 @@
+#!/usr/bin/env python3
+"""Reconcile least-privilege LiteLLM workload keys without printing secrets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+KEY_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+ALIAS_RE = re.compile(r"^fleet-[a-z0-9-]+$")
+ENV_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]+$")
+REPOSITORY_RE = re.compile(r"^FleetWorkAI/[A-Za-z0-9_.-]+$")
+MANAGED_FIELDS = (
+    "key_alias",
+    "models",
+    "allowed_routes",
+    "permissions",
+    "rpm_limit",
+    "tpm_limit",
+    "max_parallel_requests",
+    "max_budget",
+    "budget_duration",
+    "metadata",
+    "blocked",
+)
+
+
+class ReconcileError(RuntimeError):
+    """A desired-state, API, or secret-sink invariant failed."""
+
+
+class JsonClient:
+    def __init__(self, base_url: str, token: str, user_agent: str):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.user_agent = user_agent
+
+    def request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+        body = None if payload is None else json.dumps(payload, separators=(",", ":")).encode()
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": self.user_agent,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as error:
+            error.read()
+            raise ReconcileError(f"{method} {path.split('?')[0]} returned HTTP {error.code}") from error
+        except urllib.error.URLError as error:
+            raise ReconcileError(f"{method} {path.split('?')[0]} is unavailable") from error
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise ReconcileError(f"{method} {path.split('?')[0]} returned invalid JSON") from error
+
+    def get(self, path: str) -> Any:
+        return self.request("GET", path)
+
+    def post(self, path: str, payload: dict[str, Any]) -> Any:
+        return self.request("POST", path, payload)
+
+    def patch(self, path: str, payload: dict[str, Any]) -> Any:
+        return self.request("PATCH", path, payload)
+
+
+class SmokeHttpClient:
+    """Status-only client. Response bodies and authorization values never escape."""
+
+    def request(
+        self,
+        base_url: str,
+        key: str,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> int:
+        body = None if payload is None else json.dumps(payload, separators=(",", ":")).encode()
+        request = urllib.request.Request(
+            f"{base_url.rstrip('/')}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+                "User-Agent": "fleetwork-litellm-key-smoke/1",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=45) as response:
+                return response.status
+        except urllib.error.HTTPError as error:
+            status = error.code
+            error.close()
+            return status
+        except urllib.error.URLError as error:
+            raise ReconcileError(f"{method} {path.split('?')[0]} smoke is unavailable") from error
+
+
+@dataclass(frozen=True)
+class Sink:
+    type: str
+    key: str
+    application_uuid: str | None = None
+    is_preview: bool = False
+    repository: str | None = None
+    environment: str | None = None
+    fingerprint_key: str | None = None
+
+
+@dataclass(frozen=True)
+class Workload:
+    id: str
+    key_alias: str
+    legacy_aliases: tuple[str, ...]
+    desired: dict[str, Any]
+    sinks: tuple[Sink, ...]
+
+    @property
+    def aliases(self) -> frozenset[str]:
+        return frozenset((self.key_alias, *self.legacy_aliases))
+
+
+@dataclass(frozen=True)
+class CurrentKey:
+    identifier: str
+    data: dict[str, Any]
+
+
+@dataclass
+class AppliedChange:
+    workload: Workload
+    action: str
+    identifier: str
+    previous: dict[str, Any] | None = None
+
+
+def _required_string(row: dict[str, Any], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value:
+        raise ReconcileError(f"{key} must be a non-empty string")
+    return value
+
+
+def _string_list(row: dict[str, Any], key: str) -> list[str]:
+    value = row.get(key)
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise ReconcileError(f"{key} must be a string list")
+    if len(set(value)) != len(value):
+        raise ReconcileError(f"{key} contains duplicates")
+    return value
+
+
+def _load_sink(row: Any) -> Sink:
+    if not isinstance(row, dict):
+        raise ReconcileError("each workload sink must be an object")
+    sink_type = _required_string(row, "type")
+    key = _required_string(row, "key")
+    if not ENV_KEY_RE.fullmatch(key):
+        raise ReconcileError(f"invalid secret sink key {key!r}")
+    if sink_type == "coolify_env":
+        uuid = _required_string(row, "applicationUuid")
+        if row.get("isPreview", False) not in (True, False):
+            raise ReconcileError("Coolify isPreview must be boolean")
+        return Sink(sink_type, key, application_uuid=uuid, is_preview=bool(row.get("isPreview")))
+    if sink_type == "github_environment_secret":
+        repository = _required_string(row, "repository")
+        environment = _required_string(row, "environment")
+        fingerprint_key = _required_string(row, "fingerprintKey")
+        if not REPOSITORY_RE.fullmatch(repository):
+            raise ReconcileError("invalid GitHub secret repository")
+        if not ENV_KEY_RE.fullmatch(fingerprint_key) or fingerprint_key == key:
+            raise ReconcileError("invalid GitHub fingerprint variable")
+        return Sink(
+            sink_type,
+            key,
+            repository=repository,
+            environment=environment,
+            fingerprint_key=fingerprint_key,
+        )
+    raise ReconcileError(f"unsupported secret sink type {sink_type!r}")
+
+
+def load_config(path: Path, catalog_path: Path) -> tuple[str, tuple[Workload, ...]]:
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReconcileError(f"cannot read workload key config {path}") from error
+    if not isinstance(raw, dict) or raw.get("schemaVersion") != 1:
+        raise ReconcileError("unsupported workload key config schema")
+    catalog_version = _required_string(raw, "catalogVersion")
+    if raw.get("litellmVersion") != "1.83.10":
+        raise ReconcileError("workload key contract must target deployed LiteLLM 1.83.10")
+    rows = raw.get("workloads")
+    if not isinstance(rows, list) or not rows:
+        raise ReconcileError("workloads must be a non-empty list")
+
+    workloads: list[Workload] = []
+    aliases: set[str] = set()
+    ids: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ReconcileError("each workload must be an object")
+        workload_id = _required_string(row, "id")
+        alias = _required_string(row, "keyAlias")
+        legacy = _string_list(row, "legacyAliases")
+        models = _string_list(row, "models")
+        routes = _string_list(row, "allowedRoutes")
+        permissions = row.get("permissions")
+        limits = row.get("limits")
+        if not ALIAS_RE.fullmatch(alias) or any(not ALIAS_RE.fullmatch(item) for item in legacy):
+            raise ReconcileError(f"workload {workload_id} has an invalid key alias")
+        if not routes:
+            raise ReconcileError(f"workload {workload_id} must be fail-closed to explicit routes")
+        if not isinstance(permissions, dict) or any(value is not True for value in permissions.values()):
+            raise ReconcileError(f"workload {workload_id} permissions must contain only true grants")
+        if not isinstance(limits, dict):
+            raise ReconcileError(f"workload {workload_id} limits must be an object")
+        for field in ("rpm", "tpm", "maxParallelRequests"):
+            if field in limits and (not isinstance(limits[field], int) or limits[field] <= 0):
+                raise ReconcileError(f"workload {workload_id} limit {field} must be positive")
+        if ("maxBudgetUsd" in limits) != ("budgetDuration" in limits):
+            raise ReconcileError(f"workload {workload_id} budget limit and duration must be paired")
+        if "maxBudgetUsd" in limits and (
+            not isinstance(limits["maxBudgetUsd"], (int, float)) or limits["maxBudgetUsd"] <= 0
+        ):
+            raise ReconcileError(f"workload {workload_id} maxBudgetUsd must be positive")
+        sinks = tuple(_load_sink(item) for item in row.get("sinks", []))
+        if not sinks:
+            raise ReconcileError(f"workload {workload_id} must declare at least one secret sink")
+        desired = {
+            "key_alias": alias,
+            "models": sorted(models),
+            "allowed_routes": sorted(routes),
+            "permissions": permissions,
+            "rpm_limit": limits.get("rpm"),
+            "tpm_limit": limits.get("tpm"),
+            "max_parallel_requests": limits.get("maxParallelRequests"),
+            "max_budget": limits.get("maxBudgetUsd"),
+            "budget_duration": limits.get("budgetDuration"),
+            "metadata": {
+                "managed_by": "fleetwork",
+                "workload": workload_id,
+                "catalog_version": catalog_version,
+            },
+            "blocked": False,
+        }
+        all_aliases = (alias, *legacy)
+        if workload_id in ids or any(item in aliases for item in all_aliases):
+            raise ReconcileError("workload ids and current/legacy aliases must be globally unique")
+        ids.add(workload_id)
+        aliases.update(all_aliases)
+        workloads.append(Workload(workload_id, alias, tuple(legacy), desired, sinks))
+    result = tuple(workloads)
+    validate_against_catalog(catalog_path, catalog_version, result)
+    return catalog_version, result
+
+
+def validate_against_catalog(
+    catalog_path: Path,
+    catalog_version: str,
+    workloads: tuple[Workload, ...],
+) -> None:
+    try:
+        catalog = json.loads(catalog_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReconcileError(f"cannot read model catalog {catalog_path}") from error
+    if not isinstance(catalog, dict) or catalog.get("catalogVersion") != catalog_version:
+        raise ReconcileError("workload keys and model catalog versions do not match")
+    model_rows = catalog.get("models")
+    internal_rows = catalog.get("internalModels")
+    if not isinstance(model_rows, list) or not isinstance(internal_rows, list):
+        raise ReconcileError("model catalog has an invalid shape")
+    # `selectable` gouverne le sélecteur de l'interface, pas l'exécution. Une clé
+    # de workload doit couvrir tout ce qui peut encore tourner, alias dépréciés
+    # compris, sinon la dépréciation coupe les agents déjà configurés au lieu de
+    # les laisser drainer. Seul `retired` sort du périmètre exécutable.
+    chat = sorted(
+        row.get("alias")
+        for row in model_rows
+        if isinstance(row, dict)
+        and isinstance(row.get("lifecycle"), dict)
+        and row["lifecycle"].get("status") in ("active", "deprecated")
+        and isinstance(row.get("alias"), str)
+    )
+    embeddings = sorted(
+        row.get("alias")
+        for row in internal_rows
+        if isinstance(row, dict)
+        and row.get("purpose") == "embedding"
+        and isinstance(row.get("alias"), str)
+    )
+    if len(chat) != 6 or embeddings != ["text-embedding-3-small"]:
+        raise ReconcileError("model catalog must expose six executable chat aliases and one embedding route")
+    by_id = {workload.id: workload for workload in workloads}
+    if set(by_id) != {"runner", "coordinator", "catalog-probe", "spend-reader"}:
+        raise ReconcileError("workload key config must define the four governed workloads")
+    if by_id["runner"].desired["models"] != sorted((*chat, *embeddings)):
+        raise ReconcileError("runner key models do not match the governed catalog")
+    if by_id["coordinator"].desired["models"] != ["gpt-5-nano"]:
+        raise ReconcileError("coordinator key must be limited to gpt-5-nano")
+    if by_id["catalog-probe"].desired["models"] != chat:
+        raise ReconcileError("catalog probe key models do not match selectable chat aliases")
+    if by_id["spend-reader"].desired["models"]:
+        raise ReconcileError("spend reader key must not grant model access")
+    if by_id["spend-reader"].desired["permissions"]:
+        raise ReconcileError("spend reader must not require Enterprise-only permissions")
+    if by_id["spend-reader"].desired["allowed_routes"] != ["/spend/logs"]:
+        raise ReconcileError("spend reader must be limited to /spend/logs")
+
+
+def _list_rows(payload: Any) -> tuple[list[dict[str, Any]], int]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("keys"), list):
+        raise ReconcileError("LiteLLM /key/list returned an invalid shape")
+    rows = [row for row in payload["keys"] if isinstance(row, dict)]
+    if len(rows) != len(payload["keys"]):
+        raise ReconcileError("LiteLLM /key/list returned a non-object key")
+    pages = payload.get("total_pages", 1)
+    if not isinstance(pages, int) or pages < 1:
+        raise ReconcileError("LiteLLM /key/list returned an invalid page count")
+    return rows, pages
+
+
+def list_all_keys(client: JsonClient) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    page = 1
+    total_pages = 1
+    while page <= total_pages:
+        payload = client.get(f"/key/list?page={page}&size=100&return_full_object=true")
+        page_rows, total_pages = _list_rows(payload)
+        rows.extend(page_rows)
+        if total_pages > 1000:
+            raise ReconcileError("LiteLLM key pagination exceeds the safety bound")
+        page += 1
+    return rows
+
+
+def _key_identifier(row: dict[str, Any]) -> str:
+    for field in ("token", "key_hash", "key"):
+        value = row.get(field)
+        if isinstance(value, str) and KEY_HASH_RE.fullmatch(value.lower()):
+            return value.lower()
+    raise ReconcileError("LiteLLM key row lacks an immutable hashed identifier")
+
+
+def index_managed_keys(rows: list[dict[str, Any]], workloads: tuple[Workload, ...]) -> dict[str, CurrentKey]:
+    indexed: dict[str, CurrentKey] = {}
+    workload_ids = {workload.id for workload in workloads}
+    for row in rows:
+        metadata = row.get("metadata")
+        if (
+            isinstance(metadata, dict)
+            and metadata.get("managed_by") == "fleetwork"
+            and metadata.get("workload") not in workload_ids
+        ):
+            raise ReconcileError("LiteLLM contains a Fleetwork-managed key for an unknown workload")
+    for workload in workloads:
+        matches = []
+        for row in rows:
+            metadata = row.get("metadata")
+            metadata_match = (
+                isinstance(metadata, dict)
+                and metadata.get("managed_by") == "fleetwork"
+                and metadata.get("workload") == workload.id
+                and metadata.get("key_role", "current") == "current"
+            )
+            if row.get("key_alias") in workload.aliases or metadata_match:
+                matches.append(row)
+        if len(matches) > 1:
+            raise ReconcileError(f"workload {workload.id} has duplicate managed keys")
+        if matches:
+            indexed[workload.id] = CurrentKey(_key_identifier(matches[0]), matches[0])
+    identifiers = [current.identifier for current in indexed.values()]
+    if len(identifiers) != len(set(identifiers)):
+        raise ReconcileError("one LiteLLM key is assigned to multiple workloads")
+    return indexed
+
+
+def _normalized(field: str, value: Any) -> Any:
+    if field in ("models", "allowed_routes"):
+        return sorted(value) if isinstance(value, list) else value
+    if field == "metadata":
+        return value if isinstance(value, dict) else {}
+    return value
+
+
+def drift_fields(current: dict[str, Any], desired: dict[str, Any]) -> list[str]:
+    drift: list[str] = []
+    for field in MANAGED_FIELDS:
+        expected = desired[field]
+        actual = current.get(field)
+        if field == "metadata":
+            if actual != expected:
+                drift.append(field)
+        elif _normalized(field, actual) != _normalized(field, expected):
+            drift.append(field)
+    return drift
+
+
+def desired_update(identifier: str, desired: dict[str, Any]) -> dict[str, Any]:
+    return {"key": identifier, **desired}
+
+
+def snapshot_for_rollback(current: CurrentKey) -> dict[str, Any]:
+    snapshot = {"key": current.identifier}
+    for field in MANAGED_FIELDS:
+        snapshot[field] = current.data.get(field)
+    return snapshot
+
+
+def _find_by_alias(client: JsonClient, workload: Workload) -> CurrentKey | None:
+    matches = []
+    for row in list_all_keys(client):
+        metadata = row.get("metadata")
+        metadata_match = (
+            isinstance(metadata, dict)
+            and metadata.get("managed_by") == "fleetwork"
+            and metadata.get("workload") == workload.id
+            and metadata.get("key_role", "current") == "current"
+        )
+        if row.get("key_alias") in workload.aliases or metadata_match:
+            matches.append(row)
+    if len(matches) > 1:
+        raise ReconcileError(f"workload {workload.id} has duplicate managed keys")
+    if not matches:
+        return None
+    return CurrentKey(_key_identifier(matches[0]), matches[0])
+
+
+def _created_secret(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        raise ReconcileError("LiteLLM /key/generate returned an invalid shape")
+    secret = payload.get("key")
+    if not isinstance(secret, str) or len(secret) < 20:
+        raise ReconcileError("LiteLLM /key/generate did not return a usable key")
+    return secret
+
+
+def create_key_or_revoke_ambiguous(client: JsonClient, workload: Workload) -> tuple[str, str]:
+    try:
+        payload = client.post("/key/generate", workload.desired)
+        secret = _created_secret(payload)
+        return secret, hashlib.sha256(secret.encode()).hexdigest()
+    except ReconcileError as original:
+        try:
+            recovered = _find_by_alias(client, workload)
+            if recovered is not None:
+                client.post("/key/delete", {"keys": [recovered.identifier]})
+        except Exception as cleanup_error:
+            raise ReconcileError(
+                f"workload {workload.id} key creation is ambiguous and cleanup could not be proven"
+            ) from cleanup_error
+        raise original
+
+
+def rotation_candidates(
+    rows: list[dict[str, Any]], workload: Workload
+) -> list[CurrentKey]:
+    candidates: list[CurrentKey] = []
+    for row in rows:
+        metadata = row.get("metadata")
+        if (
+            isinstance(metadata, dict)
+            and metadata.get("managed_by") == "fleetwork"
+            and metadata.get("workload") == workload.id
+            and metadata.get("key_role") == "rotation_candidate"
+        ):
+            candidates.append(CurrentKey(_key_identifier(row), row))
+    identifiers = [candidate.identifier for candidate in candidates]
+    if len(identifiers) != len(set(identifiers)):
+        raise ReconcileError(f"workload {workload.id} has duplicate rotation candidates")
+    return candidates
+
+
+def create_replacement_or_revoke_ambiguous(
+    client: JsonClient, workload: Workload, previous_identifiers: set[str]
+) -> tuple[str, CurrentKey, dict[str, Any]]:
+    suffix = secrets.token_hex(4)
+    candidate_desired = {
+        **workload.desired,
+        "key_alias": f"{workload.key_alias}-next-{suffix}",
+        "metadata": {
+            **workload.desired["metadata"],
+            "key_role": "rotation_candidate",
+        },
+    }
+    try:
+        payload = client.post("/key/generate", candidate_desired)
+        secret = _created_secret(payload)
+        identifier = hashlib.sha256(secret.encode()).hexdigest()
+        return secret, CurrentKey(identifier, candidate_desired), candidate_desired
+    except ReconcileError as original:
+        try:
+            candidates = []
+            for row in list_all_keys(client):
+                if row.get("key_alias") == candidate_desired["key_alias"]:
+                    identifier = _key_identifier(row)
+                    if identifier not in previous_identifiers:
+                        candidates.append(identifier)
+            if len(candidates) == 1:
+                client.post("/key/delete", {"keys": candidates})
+            elif candidates:
+                raise ReconcileError("replacement candidates are ambiguous")
+        except Exception as cleanup_error:
+            raise ReconcileError(
+                f"workload {workload.id} replacement creation is ambiguous and cleanup could not be proven"
+            ) from cleanup_error
+        raise original
+
+
+def _coolify_env_rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        payload = payload.get("data")
+    if not isinstance(payload, list) or any(not isinstance(row, dict) for row in payload):
+        raise ReconcileError("Coolify returned invalid environment variables")
+    return payload
+
+
+def write_coolify_secret(client: JsonClient, sink: Sink, secret: str) -> None:
+    path = f"/applications/{sink.application_uuid}/envs"
+    rows = _coolify_env_rows(client.get(path))
+    matches = [
+        row
+        for row in rows
+        if (row.get("key") or row.get("name")) == sink.key
+        and bool(row.get("is_preview")) == sink.is_preview
+    ]
+    if len(matches) > 1:
+        raise ReconcileError(f"Coolify has duplicate {sink.key} rows in the requested scope")
+    payload = {"key": sink.key, "value": secret, "is_preview": sink.is_preview}
+    if matches:
+        client.patch(path, payload)
+    else:
+        client.post(path, payload)
+    reread = _coolify_env_rows(client.get(path))
+    verified = [
+        row
+        for row in reread
+        if (row.get("key") or row.get("name")) == sink.key
+        and bool(row.get("is_preview")) == sink.is_preview
+    ]
+    if len(verified) != 1 or not isinstance(verified[0].get("value"), str):
+        raise ReconcileError(f"Coolify did not retain one exact {sink.key} row")
+    if not hmac.compare_digest(verified[0]["value"], secret):
+        raise ReconcileError(f"Coolify did not retain the exact {sink.key} secret")
+
+
+def write_github_secret(sink: Sink, secret: str, github_token: str) -> None:
+    environment = {**os.environ, "GH_TOKEN": github_token}
+    command = [
+        "gh",
+        "secret",
+        "set",
+        sink.key,
+        "--env",
+        str(sink.environment),
+        "--repo",
+        str(sink.repository),
+    ]
+    try:
+        subprocess.run(
+            command,
+            input=secret.encode(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=environment,
+            check=True,
+            timeout=30,
+        )
+        fingerprint = hashlib.sha256(secret.encode()).hexdigest()
+        subprocess.run(
+            [
+                "gh",
+                "variable",
+                "set",
+                str(sink.fingerprint_key),
+                "--env",
+                str(sink.environment),
+                "--repo",
+                str(sink.repository),
+                "--body",
+                fingerprint,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=environment,
+            check=True,
+            timeout=30,
+        )
+        secrets, fingerprints = read_github_sink(sink, github_token)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as error:
+        raise ReconcileError(f"GitHub could not store environment secret {sink.key}") from error
+    fingerprint_row = fingerprints.get(str(sink.fingerprint_key), {})
+    secret_updated = secrets.get(sink.key, "")
+    fingerprint_updated = fingerprint_row.get("updated_at", "")
+    if (
+        not secret_updated
+        or not fingerprint_updated
+        or secret_updated > fingerprint_updated
+        or not hmac.compare_digest(fingerprint_row.get("value", ""), fingerprint)
+    ):
+        raise ReconcileError(f"GitHub could not verify environment secret {sink.key}")
+
+
+def read_github_sink(
+    sink: Sink, github_token: str
+) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    environment = {**os.environ, "GH_TOKEN": github_token}
+    try:
+        listed = subprocess.run(
+            [
+                "gh",
+                "secret",
+                "list",
+                "--env",
+                str(sink.environment),
+                "--repo",
+                str(sink.repository),
+                "--json",
+                "name,updatedAt",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=environment,
+            check=True,
+            timeout=30,
+        )
+        secrets = {
+            row.get("name"): row.get("updatedAt")
+            for row in json.loads(listed.stdout)
+            if isinstance(row, dict)
+            and isinstance(row.get("name"), str)
+            and isinstance(row.get("updatedAt"), str)
+        }
+        variables = subprocess.run(
+            [
+                "gh",
+                "variable",
+                "list",
+                "--env",
+                str(sink.environment),
+                "--repo",
+                str(sink.repository),
+                "--json",
+                "name,value,updatedAt",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=environment,
+            check=True,
+            timeout=30,
+        )
+        fingerprints = {
+            row.get("name"): {
+                "value": row.get("value"),
+                "updated_at": row.get("updatedAt"),
+            }
+            for row in json.loads(variables.stdout)
+            if isinstance(row, dict)
+            and isinstance(row.get("name"), str)
+            and isinstance(row.get("value"), str)
+            and isinstance(row.get("updatedAt"), str)
+        }
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as error:
+        raise ReconcileError(f"GitHub could not inspect environment secret {sink.key}") from error
+    return secrets, fingerprints
+
+
+def inspect_secret_sinks(
+    workloads: tuple[Workload, ...],
+    indexed: dict[str, CurrentKey],
+    coolify: JsonClient | None,
+    github_token: str,
+) -> dict[str, list[str]]:
+    drift: dict[str, list[str]] = {}
+    for workload in workloads:
+        current = indexed.get(workload.id)
+        for sink in workload.sinks:
+            if sink.type == "coolify_env":
+                if coolify is None:
+                    raise ReconcileError("Coolify credentials are required by a workload secret sink")
+                path = f"/applications/{sink.application_uuid}/envs"
+                rows = _coolify_env_rows(coolify.get(path))
+                matches = [
+                    row
+                    for row in rows
+                    if (row.get("key") or row.get("name")) == sink.key
+                    and bool(row.get("is_preview")) == sink.is_preview
+                ]
+                if len(matches) > 1:
+                    raise ReconcileError(f"Coolify has duplicate {sink.key} rows in the requested scope")
+                if current is not None:
+                    value = matches[0].get("value") if len(matches) == 1 else None
+                    fingerprint = (
+                        hashlib.sha256(value.encode()).hexdigest()
+                        if isinstance(value, str)
+                        else ""
+                    )
+                    if not hmac.compare_digest(fingerprint, current.identifier):
+                        drift.setdefault(workload.id, []).append(f"coolify:{sink.key}")
+            else:
+                if not github_token:
+                    raise ReconcileError(
+                        "FLEETWORK_GITHUB_WRITE_TOKEN is required by a GitHub secret sink"
+                    )
+                secrets, fingerprints = read_github_sink(sink, github_token)
+                if current is not None:
+                    expected = current.identifier
+                    fingerprint_row = fingerprints.get(str(sink.fingerprint_key), {})
+                    actual = fingerprint_row.get("value", "")
+                    secret_updated = secrets.get(sink.key, "")
+                    fingerprint_updated = fingerprint_row.get("updated_at", "")
+                    if (
+                        not secret_updated
+                        or not fingerprint_updated
+                        or secret_updated > fingerprint_updated
+                        or not hmac.compare_digest(actual, expected)
+                    ):
+                        drift.setdefault(workload.id, []).append(f"github:{sink.key}")
+    return drift
+
+
+def publish_secret(
+    sinks: tuple[Sink, ...],
+    secret: str,
+    coolify: JsonClient | None,
+    github_token: str,
+) -> None:
+    for sink in sinks:
+        if sink.type == "coolify_env":
+            if coolify is None:
+                raise ReconcileError("Coolify credentials are required by a workload secret sink")
+            write_coolify_secret(coolify, sink, secret)
+        else:
+            if not github_token:
+                raise ReconcileError("FLEETWORK_GITHUB_WRITE_TOKEN is required by a GitHub secret sink")
+            write_github_secret(sink, secret, github_token)
+
+
+def secret_sink_matches(
+    workload: Workload,
+    sink: Sink,
+    candidate: CurrentKey,
+    coolify: JsonClient | None,
+    github_token: str,
+) -> bool:
+    """Inspect one sink independently so partial publication is never hidden."""
+    isolated = Workload(
+        workload.id,
+        workload.key_alias,
+        workload.legacy_aliases,
+        workload.desired,
+        (sink,),
+    )
+    return not inspect_secret_sinks(
+        (isolated,),
+        {workload.id: candidate},
+        coolify,
+        github_token,
+    )
+
+
+def rotate_key(
+    workload: Workload,
+    current: CurrentKey | None,
+    litellm: JsonClient,
+    coolify: JsonClient | None,
+    github_token: str,
+) -> str:
+    rows = list_all_keys(litellm)
+    pending = rotation_candidates(rows, workload)
+    if len(pending) >= 5:
+        raise ReconcileError(
+            f"workload {workload.id} has too many pending rotation candidates; manual review required"
+        )
+
+    if current is not None and pending and not drift_fields(current.data, workload.desired):
+        current_sink_drift = inspect_secret_sinks(
+            (workload,), {workload.id: current}, coolify, github_token
+        )
+        if not current_sink_drift:
+            stale = sorted(candidate.identifier for candidate in pending)
+            litellm.post("/key/delete", {"keys": stale})
+            remaining = rotation_candidates(list_all_keys(litellm), workload)
+            if remaining:
+                raise ReconcileError(
+                    f"workload {workload.id} stale rotation candidate cleanup is incomplete"
+                )
+            return current.identifier
+
+    published = []
+    partial_or_ambiguous = []
+    for candidate in pending:
+        matching = 0
+        uncertain = False
+        for sink in workload.sinks:
+            try:
+                matching += int(
+                    secret_sink_matches(
+                        workload, sink, candidate, coolify, github_token
+                    )
+                )
+            except ReconcileError:
+                uncertain = True
+        if matching == len(workload.sinks):
+            published.append(candidate)
+        elif matching > 0 or uncertain:
+            partial_or_ambiguous.append(candidate)
+    if len(published) > 1:
+        raise ReconcileError(
+            f"workload {workload.id} has multiple published rotation candidates"
+        )
+    if published:
+        return complete_rotation(workload, current, published[0], pending, litellm)
+    if partial_or_ambiguous:
+        raise ReconcileError(
+            f"workload {workload.id} has a partially published or uninspectable rotation "
+            "candidate; it was kept active and requires sink recovery"
+        )
+
+    previous_identifiers = {candidate.identifier for candidate in pending}
+    if current is not None:
+        previous_identifiers.add(current.identifier)
+    secret, provisional, candidate_desired = create_replacement_or_revoke_ambiguous(
+        litellm, workload, previous_identifiers
+    )
+    identifier = provisional.identifier
+    replacement = next(
+        (CurrentKey(_key_identifier(row), row) for row in list_all_keys(litellm)
+         if row.get("key_alias") == candidate_desired["key_alias"]),
+        None,
+    )
+    if replacement is None or drift_fields(replacement.data, candidate_desired):
+        litellm.post("/key/delete", {"keys": [identifier]})
+        raise ReconcileError(f"workload {workload.id} replacement failed verification")
+
+    publication_error: Exception | None = None
+    for _ in range(3):
+        try:
+            publish_secret(workload.sinks, secret, coolify, github_token)
+            publication_error = None
+            break
+        except Exception as error:
+            publication_error = error
+    if publication_error is not None:
+        # Inspect every sink independently. A candidate is revocable only when
+        # every Coolify sink proves it did not receive the new secret. If one
+        # sink did receive it, or any sink is write-only/unavailable, keep both
+        # keys active so no deployed workload is left with a dead credential.
+        matching = 0
+        uncertain = False
+        for sink in workload.sinks:
+            try:
+                matching += int(
+                    secret_sink_matches(
+                        workload, sink, replacement, coolify, github_token
+                    )
+                )
+            except Exception:
+                uncertain = True
+        if (
+            matching == 0
+            and not uncertain
+            and all(sink.type == "coolify_env" for sink in workload.sinks)
+        ):
+            litellm.post("/key/delete", {"keys": [identifier]})
+            raise ReconcileError(
+                f"workload {workload.id} rotation did not reach Coolify; replacement revoked"
+            ) from publication_error
+        raise ReconcileError(
+            f"workload {workload.id} rotation publication is ambiguous; the identified candidate was kept active"
+        ) from publication_error
+
+    published_drift = inspect_secret_sinks(
+        (workload,), {workload.id: replacement}, coolify, github_token
+    )
+    if published_drift:
+        raise ReconcileError(
+            f"workload {workload.id} replacement fingerprint is ambiguous; the identified candidate was kept active"
+        )
+
+    return complete_rotation(workload, current, replacement, [*pending, replacement], litellm)
+
+
+def complete_rotation(
+    workload: Workload,
+    current: CurrentKey | None,
+    replacement: CurrentKey,
+    candidates: list[CurrentKey],
+    litellm: JsonClient,
+) -> str:
+    if current is not None and current.identifier != replacement.identifier:
+        litellm.post("/key/delete", {"keys": [current.identifier]})
+    litellm.post(
+        "/key/update",
+        desired_update(replacement.identifier, workload.desired),
+    )
+    verified = _find_by_alias(litellm, workload)
+    if (
+        verified is None
+        or verified.identifier != replacement.identifier
+        or drift_fields(verified.data, workload.desired)
+    ):
+        raise ReconcileError(
+            f"workload {workload.id} rotation final verification failed; the published candidate remains active"
+        )
+    stale = sorted(
+        candidate.identifier
+        for candidate in candidates
+        if candidate.identifier != replacement.identifier
+    )
+    if stale:
+        litellm.post("/key/delete", {"keys": stale})
+    return replacement.identifier
+
+
+def _coolify_sink_secret(coolify: JsonClient | None, sink: Sink) -> str:
+    if coolify is None:
+        raise ReconcileError("Coolify credentials are required by workload smoke")
+    rows = _coolify_env_rows(coolify.get(f"/applications/{sink.application_uuid}/envs"))
+    matches = [
+        row
+        for row in rows
+        if (row.get("key") or row.get("name")) == sink.key
+        and bool(row.get("is_preview")) == sink.is_preview
+    ]
+    if len(matches) != 1 or not isinstance(matches[0].get("value"), str):
+        raise ReconcileError(f"Coolify smoke secret {sink.key} is missing or duplicated")
+    value = matches[0]["value"]
+    if not value:
+        raise ReconcileError(f"Coolify smoke secret {sink.key} is empty")
+    return value
+
+
+def _smoke_secrets(
+    workloads: tuple[Workload, ...],
+    indexed: dict[str, CurrentKey],
+    coolify: JsonClient | None,
+    environment: dict[str, str],
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for workload in workloads:
+        current = indexed.get(workload.id)
+        if current is None or drift_fields(current.data, workload.desired):
+            raise ReconcileError(f"workload {workload.id} must be current before smoke")
+        if workload.id == "catalog-probe":
+            secret = environment.get("FLEETWORK_SMOKE_CATALOG_PROBE_KEY", "")
+            if not secret:
+                raise ReconcileError("catalog probe smoke secret is required")
+        else:
+            coolify_sinks = [sink for sink in workload.sinks if sink.type == "coolify_env"]
+            if len(coolify_sinks) != 1:
+                raise ReconcileError(f"workload {workload.id} must have one readable smoke sink")
+            secret = _coolify_sink_secret(coolify, coolify_sinks[0])
+        fingerprint = hashlib.sha256(secret.encode()).hexdigest()
+        if not hmac.compare_digest(fingerprint, current.identifier):
+            raise ReconcileError(f"workload {workload.id} smoke secret fingerprint does not match")
+        resolved[workload.id] = secret
+    return resolved
+
+
+def smoke_workload_keys(
+    workloads: tuple[Workload, ...],
+    indexed: dict[str, CurrentKey],
+    coolify: JsonClient | None,
+    environment: dict[str, str],
+    base_url: str,
+    http: SmokeHttpClient,
+) -> dict[str, Any]:
+    """Exercise every grant with paired valid controls and exact HTTP 403 denials."""
+    keys = _smoke_secrets(workloads, indexed, coolify, environment)
+    chat = {
+        "model": "gpt-5-nano",
+        "messages": [{"role": "user", "content": "Resume en un mot: lancement termine."}],
+        "max_completion_tokens": 16,
+    }
+    gpt4o_chat = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "test"}],
+        "max_completion_tokens": 1,
+    }
+    embedding = {"model": "text-embedding-3-small", "input": ["smoke"]}
+    models_path = "/v1/models"
+    spend_path = "/spend/logs?request_id=fleetwork-permission-smoke-missing"
+    checks: tuple[tuple[str, str, str, str, dict[str, Any] | None, str], ...] = (
+        ("runner-chat", "runner", "POST", "/v1/chat/completions", chat, "allow"),
+        (
+            "runner-embedding",
+            "runner",
+            "POST",
+            "/v1/embeddings",
+            embedding,
+            "allow",
+        ),
+        (
+            "runner-spend-logs",
+            "runner",
+            "GET",
+            spend_path,
+            None,
+            "deny",
+        ),
+        ("coordinator-chat", "coordinator", "POST", "/v1/chat/completions", chat, "allow"),
+        (
+            "coordinator-forbidden-model",
+            "coordinator",
+            "POST",
+            "/v1/chat/completions",
+            gpt4o_chat,
+            "deny",
+        ),
+        (
+            "coordinator-model-list-refusal",
+            "coordinator",
+            "GET",
+            models_path,
+            None,
+            "deny",
+        ),
+        ("catalog-probe-models", "catalog-probe", "GET", models_path, None, "allow"),
+        (
+            "catalog-probe-chat",
+            "catalog-probe",
+            "POST",
+            "/v1/chat/completions",
+            gpt4o_chat,
+            "allow",
+        ),
+        (
+            "catalog-probe-embedding-refusal",
+            "catalog-probe",
+            "POST",
+            "/v1/embeddings",
+            embedding,
+            "deny",
+        ),
+        (
+            "catalog-probe-spend-refusal",
+            "catalog-probe",
+            "GET",
+            spend_path,
+            None,
+            "deny",
+        ),
+        (
+            "spend-reader-logs",
+            "spend-reader",
+            "GET",
+            spend_path,
+            None,
+            "allow",
+        ),
+        (
+            "spend-reader-chat-refusal",
+            "spend-reader",
+            "POST",
+            "/v1/chat/completions",
+            chat,
+            "deny",
+        ),
+        (
+            "spend-reader-model-list-refusal",
+            "spend-reader",
+            "GET",
+            models_path,
+            None,
+            "deny",
+        ),
+    )
+    report: list[dict[str, str | int]] = []
+    for name, workload_id, method, path, payload, expectation in checks:
+        status = http.request(base_url, keys[workload_id], method, path, payload)
+        accepted = 200 <= status < 300 if expectation == "allow" else status == 403
+        if not accepted:
+            raise ReconcileError(
+                f"workload smoke {name} expected {expectation} but returned HTTP {status}"
+            )
+        report.append({"check": name, "status": status})
+    return {"status": "smoke-passed", "checks": report}
+
+
+def reconcile(
+    mode: str,
+    workloads: tuple[Workload, ...],
+    litellm: JsonClient,
+    coolify: JsonClient | None = None,
+    github_token: str = "",
+    verify_secret_sinks: bool = True,
+    rotate_workload: str | None = None,
+) -> dict[str, Any]:
+    rows = list_all_keys(litellm)
+    indexed = index_managed_keys(rows, workloads)
+    pending = {
+        workload.id: rotation_candidates(rows, workload)
+        for workload in workloads
+    }
+    sink_drift = (
+        inspect_secret_sinks(workloads, indexed, coolify, github_token)
+        if verify_secret_sinks
+        else {}
+    )
+    if mode == "rotate":
+        if not rotate_workload:
+            raise ReconcileError("rotate requires --workload")
+        selected = next(
+            (workload for workload in workloads if workload.id == rotate_workload),
+            None,
+        )
+        if selected is None:
+            raise ReconcileError(f"unknown rotation workload {rotate_workload!r}")
+        rotate_key(
+            selected,
+            indexed.get(selected.id),
+            litellm,
+            coolify,
+            github_token,
+        )
+        return {
+            "status": "rotated",
+            "workloads": [{"workload": selected.id, "status": "rotated"}],
+        }
+    if mode == "apply" and sink_drift:
+        affected = ", ".join(sorted(sink_drift))
+        raise ReconcileError(
+            "secret sink fingerprint mismatch; explicit credential rotation is required for: "
+            + affected
+        )
+    pending_workloads = sorted(workload_id for workload_id, items in pending.items() if items)
+    if mode == "apply" and pending_workloads:
+        raise ReconcileError(
+            "pending rotation candidates require explicit rotate recovery for: "
+            + ", ".join(pending_workloads)
+        )
+    report: list[dict[str, Any]] = []
+    changes: list[AppliedChange] = []
+    try:
+        for workload in workloads:
+            current = indexed.get(workload.id)
+            if current is None:
+                item = {"workload": workload.id, "status": "missing"}
+                if pending[workload.id]:
+                    item["rotation"] = "pending"
+                report.append(item)
+                if mode == "apply":
+                    secret, identifier = create_key_or_revoke_ambiguous(litellm, workload)
+                    verified = next(
+                        (
+                            CurrentKey(_key_identifier(row), row)
+                            for row in list_all_keys(litellm)
+                            if _key_identifier(row) == identifier
+                        ),
+                        None,
+                    )
+                    if verified is None or drift_fields(verified.data, workload.desired):
+                        litellm.post("/key/delete", {"keys": [identifier]})
+                        raise ReconcileError(f"workload {workload.id} failed post-create verification")
+                    try:
+                        publish_secret(workload.sinks, secret, coolify, github_token)
+                        published_drift = inspect_secret_sinks(
+                            (workload,),
+                            {workload.id: verified},
+                            coolify,
+                            github_token,
+                        )
+                    except Exception as error:
+                        raise ReconcileError(
+                            f"workload {workload.id} credential publication is incomplete; "
+                            "the generated key was kept active to avoid a dead deployed secret"
+                        ) from error
+                    if published_drift:
+                        raise ReconcileError(
+                            f"workload {workload.id} secret fingerprint was not retained; "
+                            "the generated key was kept active to avoid a dead deployed secret"
+                        )
+                continue
+
+            drift = drift_fields(current.data, workload.desired)
+            sinks = sink_drift.get(workload.id, [])
+            if not drift and not sinks and not pending[workload.id]:
+                report.append({"workload": workload.id, "status": "current"})
+                continue
+            item: dict[str, Any] = {"workload": workload.id, "status": "drift"}
+            if drift:
+                item["fields"] = drift
+            if sinks:
+                item["sinks"] = sinks
+            if pending[workload.id]:
+                item["rotation"] = "pending"
+            report.append(item)
+            if mode == "apply":
+                previous = snapshot_for_rollback(current)
+                changes.append(AppliedChange(workload, "updated", current.identifier, previous))
+                litellm.post(
+                    "/key/update",
+                    desired_update(current.identifier, workload.desired),
+                )
+                verified = _find_by_alias(litellm, workload)
+                if verified is None or drift_fields(verified.data, workload.desired):
+                    raise ReconcileError(f"workload {workload.id} failed post-update verification")
+    except Exception as error:
+        rollback_errors: list[str] = []
+        for change in reversed(changes):
+            try:
+                if change.previous is not None:
+                    litellm.post("/key/update", change.previous)
+            except Exception:
+                rollback_errors.append(change.workload.id)
+        if rollback_errors:
+            raise ReconcileError(
+                "key reconciliation failed and rollback is incomplete for: "
+                + ", ".join(rollback_errors)
+            ) from error
+        if isinstance(error, ReconcileError):
+            raise
+        raise ReconcileError("key reconciliation failed and was rolled back") from error
+
+    remaining = [item for item in report if item["status"] != "current"]
+    return {
+        "status": "applied" if mode == "apply" else ("drift" if remaining else "current"),
+        "workloads": report,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("check", "apply", "rotate", "smoke"))
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--catalog", type=Path, required=True)
+    parser.add_argument("--workload")
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    _, workloads = load_config(args.config, args.catalog)
+    base_url = os.environ.get("LITELLM_BASE_URL", "").rstrip("/")
+    admin_key = os.environ.get("LITELLM_ADMIN_KEY", "")
+    if not base_url.startswith("https://") or not admin_key:
+        raise ReconcileError("LITELLM_BASE_URL and LITELLM_ADMIN_KEY are required")
+    litellm = JsonClient(base_url, admin_key, "fleetwork-litellm-key-reconciler/1")
+
+    coolify = None
+    coolify_url = os.environ.get("COOLIFY_URL", "").rstrip("/")
+    coolify_token = os.environ.get("COOLIFY_API_TOKEN", "")
+    if coolify_url.startswith("https://") and coolify_token:
+        coolify = JsonClient(
+            f"{coolify_url}/api/v1", coolify_token, "fleetwork-litellm-key-reconciler/1"
+        )
+    github_token = os.environ.get("FLEETWORK_GITHUB_WRITE_TOKEN", "")
+    if args.mode == "smoke":
+        indexed = index_managed_keys(list_all_keys(litellm), workloads)
+        return smoke_workload_keys(
+            workloads,
+            indexed,
+            coolify,
+            dict(os.environ),
+            base_url,
+            SmokeHttpClient(),
+        )
+    return reconcile(
+        args.mode,
+        workloads,
+        litellm,
+        coolify,
+        github_token,
+        verify_secret_sinks=True,
+        rotate_workload=args.workload,
+    )
+
+
+def main() -> int:
+    try:
+        result = run(build_parser().parse_args())
+    except ReconcileError as error:
+        print(f"LiteLLM key reconciliation refused: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 2 if result["status"] == "drift" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/catalog.v1.json
+++ b/tests/fixtures/catalog.v1.json
@@ -1,0 +1,54 @@
+{
+  "catalogVersion": "2026.08.05.4",
+  "models": [
+    {
+      "alias": "claude-opus-4-7",
+      "selectable": true,
+      "lifecycle": {
+        "status": "active"
+      }
+    },
+    {
+      "alias": "claude-sonnet-4-6",
+      "selectable": true,
+      "lifecycle": {
+        "status": "active"
+      }
+    },
+    {
+      "alias": "claude-haiku-4-5",
+      "selectable": true,
+      "lifecycle": {
+        "status": "active"
+      }
+    },
+    {
+      "alias": "gpt-5-nano",
+      "selectable": true,
+      "lifecycle": {
+        "status": "active"
+      }
+    },
+    {
+      "alias": "gpt-4o",
+      "selectable": true,
+      "lifecycle": {
+        "status": "active"
+      }
+    },
+    {
+      "alias": "gpt-4o-mini",
+      "selectable": false,
+      "lifecycle": {
+        "status": "deprecated"
+      }
+    }
+  ],
+  "internalModels": [
+    {
+      "alias": "text-embedding-3-small",
+      "purpose": "embedding",
+      "selectable": false
+    }
+  ]
+}

--- a/tests/test_check_litellm_global_config.py
+++ b/tests/test_check_litellm_global_config.py
@@ -1,0 +1,413 @@
+import copy
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.check_litellm_global_config import (
+    REQUIRED_SETTINGS,
+    ReconcileError,
+    check_actual_config,
+    check_coolify_mount,
+    check_remote_configs,
+    governed_settings,
+    load_contract,
+    read_remote_configs,
+    settings_digest,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "config/litellm-global-config.json"
+SOURCE = ROOT / "config/litellm-global-settings.yaml"
+
+
+class FakeCoolify:
+    def __init__(self, payload):
+        self.payload = copy.deepcopy(payload)
+        self.paths = []
+
+    def get(self, path):
+        self.paths.append(path)
+        return copy.deepcopy(self.payload)
+
+
+def service_payload(contract):
+    mount = contract.mount
+    return {
+        "uuid": mount.service_uuid,
+        "name": "human-readable-name-is-not-a-mount-identity",
+        "docker_compose_raw": "\n".join(
+            [
+                "services:",
+                "  litellm:",
+                "    volumes:",
+                "      - type: bind",
+                f"        source: {mount.compose_source}",
+                f"        target: {mount.container_target}",
+            ]
+        ),
+        "docker_compose": "\n".join(
+            [
+                "services:",
+                "  litellm:",
+                f"    container_name: {mount.container_name}",
+                "    volumes:",
+                f"      - '{mount.host_source}:{mount.container_target}'",
+            ]
+        ),
+    }
+
+
+class GlobalSettingsTests(unittest.TestCase):
+    def test_source_is_exact_and_digest_is_current(self):
+        contract = load_contract(CONTRACT, ROOT)
+        self.assertEqual(governed_settings(SOURCE.read_text()), REQUIRED_SETTINGS)
+        self.assertEqual(
+            contract.semantic_digest,
+            "sha256:1c0e60bca81fe2b85f00191e895a2d94c0e515f9c405bead0aa086185810d927",
+        )
+
+    def test_stale_digest_is_refused(self):
+        raw = json.loads(CONTRACT.read_text())
+        raw["settingsSemanticDigest"] = "sha256:" + "0" * 64
+        raw["settingsSource"] = "settings.yaml"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "settings.yaml").write_text(SOURCE.read_text())
+            path = root / "contract.json"
+            path.write_text(json.dumps(raw))
+            with self.assertRaisesRegex(ReconcileError, "digest is stale"):
+                load_contract(path, root)
+
+    def test_missing_false_or_nonzero_settings_fail_closed(self):
+        contract = load_contract(CONTRACT, ROOT)
+        cases = (
+            "litellm_settings:\n  include_cost_in_streaming_usage: true\n",
+            SOURCE.read_text().replace("drop_params: false", "drop_params: true"),
+            SOURCE.read_text().replace("num_retries: 0", "num_retries: 2"),
+            SOURCE.read_text().replace("max_fallbacks: 0", "max_fallbacks: 1"),
+        )
+        for actual in cases:
+            with self.subTest(actual=actual):
+                with self.assertRaisesRegex(ReconcileError, "global config drift"):
+                    check_actual_config(contract, actual)
+
+    def test_unrelated_config_and_secrets_are_ignored_and_never_reported(self):
+        contract = load_contract(CONTRACT, ROOT)
+        secret = "sk-secret-that-must-not-escape"
+        actual = SOURCE.read_text() + f"\ngeneral_settings:\n  master_key: {secret}\n"
+        report = check_actual_config(contract, actual)
+        self.assertEqual(report["status"], "current")
+        self.assertNotIn(secret, json.dumps(report))
+
+    def test_duplicate_governed_setting_is_refused(self):
+        actual = SOURCE.read_text().replace(
+            "  drop_params: false", "  drop_params: false\n  drop_params: false"
+        )
+        with self.assertRaisesRegex(ReconcileError, "duplicate YAML mapping key"):
+            governed_settings(actual)
+
+    def test_duplicate_governed_section_in_inline_or_block_form_is_refused(self):
+        cases = (
+            SOURCE.read_text()
+            + "router_settings: {num_retries: 7, max_fallbacks: 9}\n",
+            SOURCE.read_text()
+            + "router_settings:\n  num_retries: 7\n  max_fallbacks: 9\n",
+        )
+        for actual in cases:
+            with self.subTest(actual=actual):
+                with self.assertRaisesRegex(
+                    ReconcileError, "duplicate YAML mapping key"
+                ):
+                    governed_settings(actual)
+
+    def test_duplicate_governed_inline_key_is_refused(self):
+        actual = """\
+litellm_settings: {include_cost_in_streaming_usage: true, drop_params: false}
+router_settings: {num_retries: 0, num_retries: 7, max_fallbacks: 0}
+"""
+        with self.assertRaisesRegex(ReconcileError, "duplicate YAML mapping key"):
+            governed_settings(actual)
+
+    def test_invalid_plain_scalars_anywhere_fail_closed(self):
+        for invalid in ("@invalid", "`invalid", ": invalid"):
+            actual = SOURCE.read_text() + f"\ngeneral_settings:\n  unrelated: {invalid}\n"
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ReconcileError, "invalid plain YAML scalar"):
+                    governed_settings(actual)
+
+    def test_valid_plain_command_flag_outside_policy_is_accepted(self):
+        actual = SOURCE.read_text() + "\ngeneral_settings:\n  command_flag: --config\n"
+        self.assertEqual(governed_settings(actual), REQUIRED_SETTINGS)
+
+    def test_duplicate_arbitrary_key_never_leaks_its_name(self):
+        secret_key = "sk-sensitive-value-as-key"
+        actual = SOURCE.read_text() + (
+            f"\ngeneral_settings:\n  {secret_key}: first\n  {secret_key}: second\n"
+        )
+        with self.assertRaises(ReconcileError) as raised:
+            governed_settings(actual)
+        self.assertNotIn(secret_key, str(raised.exception))
+
+    def test_ambiguous_governed_structures_and_types_are_refused(self):
+        cases = (
+            SOURCE.read_text().replace(
+                "router_settings:\n  num_retries: 0\n  max_fallbacks: 0",
+                "router_settings: [0, 0]",
+            ),
+            SOURCE.read_text().replace("drop_params: false", "drop_params: 'false'"),
+            SOURCE.read_text().replace("num_retries: 0", "num_retries: false"),
+        )
+        for actual in cases:
+            with self.subTest(actual=actual):
+                with self.assertRaisesRegex(ReconcileError, "must be|invalid YAML type"):
+                    governed_settings(actual)
+
+    def test_semantic_digest_ignores_yaml_order_comments_and_whitespace(self):
+        reordered = """\
+router_settings:   # order is intentionally different
+  max_fallbacks: 0
+  num_retries: 0
+litellm_settings:
+  drop_params: false
+  include_cost_in_streaming_usage: true
+"""
+        self.assertEqual(governed_settings(reordered), REQUIRED_SETTINGS)
+        self.assertEqual(
+            settings_digest(governed_settings(reordered)),
+            settings_digest(governed_settings(SOURCE.read_text())),
+        )
+
+    def test_valid_inline_policy_is_accepted(self):
+        inline = """\
+litellm_settings: {include_cost_in_streaming_usage: true, drop_params: false}
+router_settings: {num_retries: 0, max_fallbacks: 0}
+"""
+        self.assertEqual(governed_settings(inline), REQUIRED_SETTINGS)
+
+
+class CoolifyMountTests(unittest.TestCase):
+    def test_exact_service_and_mount_are_current(self):
+        contract = load_contract(CONTRACT, ROOT)
+        client = FakeCoolify(service_payload(contract))
+        report = check_coolify_mount(contract, client)
+        self.assertEqual(
+            report,
+            {"status": "current", "serviceUuid": contract.mount.service_uuid},
+        )
+        self.assertEqual(client.paths, [f"/services/{contract.mount.service_uuid}"])
+
+    def test_mount_drift_is_refused_without_returning_compose(self):
+        contract = load_contract(CONTRACT, ROOT)
+        payload = service_payload(contract)
+        payload["docker_compose"] = payload["docker_compose"].replace(
+            contract.mount.container_target, "/tmp/other.yaml"
+        )
+        with self.assertRaises(ReconcileError) as raised:
+            check_coolify_mount(contract, FakeCoolify(payload))
+        self.assertNotIn(payload["docker_compose"], str(raised.exception))
+
+    def test_comments_and_environment_lures_do_not_satisfy_identity_or_mount(self):
+        contract = load_contract(CONTRACT, ROOT)
+        mount = contract.mount
+        payload = service_payload(contract)
+        payload["docker_compose"] = "\n".join(
+            [
+                "services:",
+                "  litellm:",
+                "    container_name: wrong-container",
+                "    environment:",
+                f"      LURE_CONTAINER: 'container_name: {mount.container_name}'",
+                f"      LURE_VOLUME: '{mount.host_source}:{mount.container_target}'",
+                f"    # container_name: {mount.container_name}",
+                f"    # - '{mount.host_source}:{mount.container_target}'",
+                "    volumes:",
+                "      - '/tmp/wrong.yaml:/app/wrong.yaml'",
+            ]
+        )
+        with self.assertRaisesRegex(ReconcileError, "container identity drift"):
+            check_coolify_mount(contract, FakeCoolify(payload))
+
+    def test_identity_and_mount_split_across_services_are_refused(self):
+        contract = load_contract(CONTRACT, ROOT)
+        mount = contract.mount
+        payload = service_payload(contract)
+        payload["docker_compose_raw"] = "\n".join(
+            [
+                "services:",
+                "  litellm:",
+                "    volumes:",
+                f"      - '{mount.compose_source}:{mount.container_target}'",
+                "  lure:",
+                "    volumes:",
+                "      - '/tmp/wrong.yaml:/app/config.yaml'",
+            ]
+        )
+        payload["docker_compose"] = "\n".join(
+            [
+                "services:",
+                "  litellm:",
+                "    container_name: wrong-container",
+                "    volumes:",
+                f"      - '{mount.host_source}:{mount.container_target}'",
+                "  lure:",
+                f"    container_name: {mount.container_name}",
+                "    volumes:",
+                f"      - '{mount.host_source}:{mount.container_target}'",
+            ]
+        )
+        with self.assertRaisesRegex(ReconcileError, "container identity drift"):
+            check_coolify_mount(contract, FakeCoolify(payload))
+
+    def test_raw_mount_on_a_different_service_is_refused(self):
+        contract = load_contract(CONTRACT, ROOT)
+        mount = contract.mount
+        payload = service_payload(contract)
+        payload["docker_compose_raw"] = "\n".join(
+            [
+                "services:",
+                "  litellm:",
+                "    volumes:",
+                "      - '/tmp/wrong.yaml:/app/config.yaml'",
+                "  lure:",
+                "    volumes:",
+                f"      - '{mount.compose_source}:{mount.container_target}'",
+            ]
+        )
+        with self.assertRaisesRegex(ReconcileError, "source mount drift"):
+            check_coolify_mount(contract, FakeCoolify(payload))
+
+    def test_wrong_rendered_volume_source_or_target_is_refused(self):
+        contract = load_contract(CONTRACT, ROOT)
+        for old, new in (
+            (contract.mount.host_source, "/tmp/wrong.yaml"),
+            (contract.mount.container_target, "/app/wrong.yaml"),
+        ):
+            payload = service_payload(contract)
+            payload["docker_compose"] = payload["docker_compose"].replace(old, new)
+            with self.subTest(new=new):
+                with self.assertRaisesRegex(ReconcileError, "rendered mount drift"):
+                    check_coolify_mount(contract, FakeCoolify(payload))
+
+    def test_duplicate_mount_target_is_refused_even_when_one_bind_is_exact(self):
+        contract = load_contract(CONTRACT, ROOT)
+        mount = contract.mount
+        for volumes in (
+            [
+                f"      - '{mount.host_source}:{mount.container_target}'",
+                f"      - '/tmp/wrong.yaml:{mount.container_target}'",
+            ],
+            [
+                f"      - '/tmp/wrong.yaml:{mount.container_target}'",
+                f"      - '{mount.host_source}:{mount.container_target}'",
+            ],
+        ):
+            payload = service_payload(contract)
+            payload["docker_compose"] = "\n".join(
+                [
+                    "services:",
+                    "  litellm:",
+                    f"    container_name: {mount.container_name}",
+                    "    volumes:",
+                    *volumes,
+                ]
+            )
+            with self.subTest(volumes=volumes):
+                with self.assertRaisesRegex(ReconcileError, "rendered mount drift"):
+                    check_coolify_mount(contract, FakeCoolify(payload))
+
+    def test_long_syntax_rendered_bind_is_current(self):
+        contract = load_contract(CONTRACT, ROOT)
+        mount = contract.mount
+        payload = service_payload(contract)
+        payload["docker_compose"] = "\n".join(
+            [
+                "services:",
+                "  litellm:",
+                f"    container_name: {mount.container_name}",
+                "    volumes:",
+                "      - type: bind",
+                f"        source: {mount.host_source}",
+                f"        target: {mount.container_target}",
+                "        read_only: true",
+            ]
+        )
+        self.assertEqual(
+            check_coolify_mount(contract, FakeCoolify(payload))["status"], "current"
+        )
+
+    def test_duplicate_compose_service_key_is_refused(self):
+        contract = load_contract(CONTRACT, ROOT)
+        payload = service_payload(contract)
+        payload["docker_compose"] += "\n  litellm:\n    container_name: duplicate\n"
+        with self.assertRaisesRegex(ReconcileError, "duplicate YAML mapping key"):
+            check_coolify_mount(contract, FakeCoolify(payload))
+
+    @patch("scripts.check_litellm_global_config.subprocess.run")
+    def test_remote_reads_use_argv_strict_host_key_sudo_and_hide_stderr(self, run):
+        contract = load_contract(CONTRACT, ROOT)
+        run.side_effect = [
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=SOURCE.read_bytes(), stderr=b""
+            ),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=SOURCE.read_bytes(), stderr=b""
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            identity = Path(directory) / "identity"
+            known_hosts = Path(directory) / "known_hosts"
+            identity.touch()
+            known_hosts.touch()
+            mounted, runtime = read_remote_configs(
+                contract, "coolify.example.test", 6969, identity, known_hosts
+            )
+        self.assertEqual((mounted, runtime), (SOURCE.read_text(), SOURCE.read_text()))
+        mounted_command = run.call_args_list[0].args[0]
+        runtime_command = run.call_args_list[1].args[0]
+        for call in run.call_args_list:
+            self.assertIn("StrictHostKeyChecking=yes", call.args[0])
+            self.assertEqual(call.kwargs["stderr"], subprocess.DEVNULL)
+        self.assertEqual(
+            mounted_command[-4:],
+            ["sudo", "-n", "cat", contract.mount.host_source],
+        )
+        self.assertEqual(
+            runtime_command[-7:],
+            [
+                "sudo",
+                "-n",
+                "docker",
+                "exec",
+                contract.mount.container_name,
+                "cat",
+                contract.mount.container_target,
+            ],
+        )
+
+    def test_host_and_runtime_must_be_byte_identical_without_secret_output(self):
+        contract = load_contract(CONTRACT, ROOT)
+        secret = "secret-host-only-value"
+        mounted = SOURCE.read_text() + f"\ngeneral_settings:\n  master_key: {secret}\n"
+        runtime = SOURCE.read_text() + "\ngeneral_settings:\n  master_key: different\n"
+        with self.assertRaises(ReconcileError) as raised:
+            check_remote_configs(contract, mounted, runtime)
+        self.assertNotIn(secret, str(raised.exception))
+
+    def test_host_and_runtime_policy_and_bytes_match(self):
+        contract = load_contract(CONTRACT, ROOT)
+        actual = SOURCE.read_text() + "\ngeneral_settings:\n  master_key: redacted-test-value\n"
+        self.assertEqual(
+            check_remote_configs(contract, actual, actual),
+            {
+                "status": "current",
+                "settingsSemanticDigest": contract.semantic_digest,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconcile_litellm_keys.py
+++ b/tests/test_reconcile_litellm_keys.py
@@ -1,0 +1,675 @@
+import copy
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.reconcile_litellm_keys import (
+    ReconcileError,
+    Sink,
+    drift_fields,
+    index_managed_keys,
+    inspect_secret_sinks,
+    load_config,
+    reconcile,
+    smoke_workload_keys,
+    write_github_secret,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "config/litellm-workload-keys.json"
+CATALOG = ROOT / "tests/fixtures/catalog.v1.json"
+SECRET = "sk-fleetwork-test-secret-never-print"
+
+
+class FakeLiteLLM:
+    def __init__(self, rows, fail_create_after_write=False, fail_delete_call=None):
+        self.rows = copy.deepcopy(rows)
+        self.calls = []
+        self.fail_create_after_write = fail_create_after_write
+        self.generate_count = 0
+        self.fail_delete_call = fail_delete_call
+        self.delete_count = 0
+
+    def get(self, path):
+        self.calls.append(("GET", path))
+        if path.startswith("/key/list?"):
+            return {"keys": copy.deepcopy(self.rows), "total_pages": 1}
+        raise AssertionError(f"unexpected GET {path}")
+
+    def post(self, path, payload):
+        self.calls.append(("POST", path, copy.deepcopy(payload)))
+        if path == "/key/generate":
+            self.generate_count += 1
+            secret = SECRET if self.generate_count == 1 else f"{SECRET}-{self.generate_count}"
+            row = copy.deepcopy(payload)
+            row["token"] = hashlib.sha256(secret.encode()).hexdigest()
+            self.rows.append(row)
+            if self.fail_create_after_write:
+                raise ReconcileError("POST /key/generate is unavailable")
+            return {"key": secret}
+        if path == "/key/update":
+            identifier = payload["key"]
+            row = next(row for row in self.rows if row["token"] == identifier)
+            row.update({key: copy.deepcopy(value) for key, value in payload.items() if key != "key"})
+            return {"status": "ok"}
+        if path == "/key/delete":
+            self.delete_count += 1
+            if self.delete_count == self.fail_delete_call:
+                raise ReconcileError("POST /key/delete is unavailable")
+            identifiers = set(payload["keys"])
+            self.rows = [row for row in self.rows if row["token"] not in identifiers]
+            return {"deleted_keys": len(identifiers)}
+        raise AssertionError(f"unexpected POST {path}")
+
+
+class FakeCoolify:
+    def __init__(self, fail_write=False):
+        self.rows = []
+        self.calls = []
+        self.fail_write = fail_write
+
+    def get(self, path):
+        self.calls.append(("GET", path))
+        return copy.deepcopy(self.rows)
+
+    def post(self, path, payload):
+        self.calls.append(("POST", path, {**payload, "value": "[redacted]"}))
+        if self.fail_write:
+            raise ReconcileError("Coolify write failed")
+        self.rows.append(copy.deepcopy(payload))
+        return {"message": "created"}
+
+    def patch(self, path, payload):
+        self.calls.append(("PATCH", path, {**payload, "value": "[redacted]"}))
+        if self.fail_write:
+            raise ReconcileError("Coolify write failed")
+        match = next(
+            row
+            for row in self.rows
+            if row["key"] == payload["key"]
+            and bool(row.get("is_preview")) == bool(payload.get("is_preview"))
+        )
+        match.update(copy.deepcopy(payload))
+        return {"message": "updated"}
+
+
+class SelectiveFailCoolify(FakeCoolify):
+    def __init__(self, failed_application_uuid):
+        super().__init__()
+        self.failed_application_uuid = failed_application_uuid
+
+    def post(self, path, payload):
+        if self.failed_application_uuid in path:
+            raise ReconcileError("Coolify write failed")
+        return super().post(path, payload)
+
+    def patch(self, path, payload):
+        if self.failed_application_uuid in path:
+            raise ReconcileError("Coolify write failed")
+        return super().patch(path, payload)
+
+
+class SmokeCoolify:
+    def __init__(self, workloads):
+        self.by_path = {}
+        for workload in workloads:
+            for sink in workload.sinks:
+                if sink.type == "coolify_env":
+                    self.by_path.setdefault(
+                        f"/applications/{sink.application_uuid}/envs", []
+                    ).append(
+                        {
+                            "key": sink.key,
+                            "value": f"{workload.id}-secret",
+                            "is_preview": sink.is_preview,
+                        }
+                    )
+
+    def get(self, path):
+        return copy.deepcopy(self.by_path.get(path, []))
+
+
+class FakeSmokeHttp:
+    def __init__(self, statuses=None):
+        self.statuses = iter(
+            statuses
+            or [200, 200, 403, 200, 403, 403, 200, 200, 403, 403, 200, 403, 403]
+        )
+        self.calls = []
+
+    def request(self, base_url, key, method, path, payload=None):
+        self.calls.append((base_url, "[redacted]", method, path, copy.deepcopy(payload)))
+        return next(self.statuses)
+
+
+def loaded():
+    return load_config(CONFIG, CATALOG)[1]
+
+
+def current_row(workload, alias=None):
+    return {
+        **copy.deepcopy(workload.desired),
+        "key_alias": alias or workload.key_alias,
+        "token": hashlib.sha256(f"{workload.id}-secret".encode()).hexdigest(),
+    }
+
+
+class ConfigTests(unittest.TestCase):
+    def test_config_is_bound_to_the_governed_catalog(self):
+        workloads = loaded()
+        self.assertEqual([workload.id for workload in workloads], [
+            "runner",
+            "coordinator",
+            "catalog-probe",
+            "spend-reader",
+        ])
+        self.assertEqual(workloads[1].desired["models"], ["gpt-5-nano"])
+        self.assertEqual(workloads[3].desired["permissions"], {})
+        self.assertEqual(workloads[3].desired["allowed_routes"], ["/spend/logs"])
+
+    def test_catalog_version_mismatch_is_refused(self):
+        raw = json.loads(CONFIG.read_text())
+        raw["catalogVersion"] = "forged"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "keys.json"
+            path.write_text(json.dumps(raw))
+            with self.assertRaisesRegex(ReconcileError, "versions do not match"):
+                load_config(path, CATALOG)
+
+    def test_duplicate_legacy_alias_is_refused(self):
+        raw = json.loads(CONFIG.read_text())
+        raw["workloads"][1]["legacyAliases"] = ["fleet-services"]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "keys.json"
+            path.write_text(json.dumps(raw))
+            with self.assertRaisesRegex(ReconcileError, "globally unique"):
+                load_config(path, CATALOG)
+
+
+class WorkloadSmokeTests(unittest.TestCase):
+    def test_every_positive_and_negative_grant_is_exercised_without_secret_output(self):
+        workloads = loaded()
+        rows = [current_row(workload) for workload in workloads]
+        indexed = index_managed_keys(rows, workloads)
+        http = FakeSmokeHttp()
+        report = smoke_workload_keys(
+            workloads,
+            indexed,
+            SmokeCoolify(workloads),
+            {"FLEETWORK_SMOKE_CATALOG_PROBE_KEY": "catalog-probe-secret"},
+            "https://litellm.example.test",
+            http,
+        )
+        self.assertEqual(report["status"], "smoke-passed")
+        self.assertEqual(len(report["checks"]), 13)
+        self.assertEqual(
+            [call[3] for call in http.calls],
+            [
+                "/v1/chat/completions",
+                "/v1/embeddings",
+                "/spend/logs?request_id=fleetwork-permission-smoke-missing",
+                "/v1/chat/completions",
+                "/v1/chat/completions",
+                "/v1/models",
+                "/v1/models",
+                "/v1/chat/completions",
+                "/v1/embeddings",
+                "/spend/logs?request_id=fleetwork-permission-smoke-missing",
+                "/spend/logs?request_id=fleetwork-permission-smoke-missing",
+                "/v1/chat/completions",
+                "/v1/models",
+            ],
+        )
+        self.assertEqual(http.calls[4][4]["model"], "gpt-4o")
+        self.assertEqual(http.calls[8][4]["model"], "text-embedding-3-small")
+        self.assertEqual(http.calls[11][4]["model"], "gpt-5-nano")
+
+        calls = {
+            check["check"]: call
+            for check, call in zip(report["checks"], http.calls, strict=True)
+        }
+        valid_control_pairs = {
+            "runner-spend-logs": "spend-reader-logs",
+            "coordinator-forbidden-model": "catalog-probe-chat",
+            "coordinator-model-list-refusal": "catalog-probe-models",
+            "catalog-probe-embedding-refusal": "runner-embedding",
+            "catalog-probe-spend-refusal": "spend-reader-logs",
+            "spend-reader-chat-refusal": "runner-chat",
+            "spend-reader-model-list-refusal": "catalog-probe-models",
+        }
+        for denied, allowed in valid_control_pairs.items():
+            with self.subTest(denied=denied, allowed=allowed):
+                self.assertEqual(calls[denied][2:], calls[allowed][2:])
+        rendered = json.dumps({"report": report, "calls": http.calls})
+        for workload in workloads:
+            self.assertNotIn(f"{workload.id}-secret", rendered)
+
+    def test_an_unexpected_allow_or_deny_status_fails_closed(self):
+        workloads = loaded()
+        indexed = index_managed_keys(
+            [current_row(workload) for workload in workloads], workloads
+        )
+        with self.assertRaisesRegex(ReconcileError, "runner-spend-logs expected deny"):
+            smoke_workload_keys(
+                workloads,
+                indexed,
+                SmokeCoolify(workloads),
+                {"FLEETWORK_SMOKE_CATALOG_PROBE_KEY": "catalog-probe-secret"},
+                "https://litellm.example.test",
+                FakeSmokeHttp([200, 200, 400]),
+            )
+
+    def test_every_negative_permission_check_requires_exact_403(self):
+        workloads = loaded()
+        indexed = index_managed_keys(
+            [current_row(workload) for workload in workloads], workloads
+        )
+        expected = [200, 200, 403, 200, 403, 403, 200, 200, 403, 403, 200, 403, 403]
+        denied = {
+            2: "runner-spend-logs",
+            4: "coordinator-forbidden-model",
+            5: "coordinator-model-list-refusal",
+            8: "catalog-probe-embedding-refusal",
+            9: "catalog-probe-spend-refusal",
+            11: "spend-reader-chat-refusal",
+            12: "spend-reader-model-list-refusal",
+        }
+        for index, check_name in denied.items():
+            statuses = expected.copy()
+            statuses[index] = 400
+            with self.subTest(check=check_name):
+                with self.assertRaisesRegex(ReconcileError, check_name):
+                    smoke_workload_keys(
+                        workloads,
+                        indexed,
+                        SmokeCoolify(workloads),
+                        {"FLEETWORK_SMOKE_CATALOG_PROBE_KEY": "catalog-probe-secret"},
+                        "https://litellm.example.test",
+                        FakeSmokeHttp(statuses),
+                    )
+
+    def test_a_failed_smoke_never_exposes_the_workload_secret(self):
+        workloads = loaded()
+        indexed = index_managed_keys(
+            [current_row(workload) for workload in workloads], workloads
+        )
+        with self.assertRaises(ReconcileError) as raised:
+            smoke_workload_keys(
+                workloads,
+                indexed,
+                SmokeCoolify(workloads),
+                {"FLEETWORK_SMOKE_CATALOG_PROBE_KEY": "catalog-probe-secret"},
+                "https://litellm.example.test",
+                FakeSmokeHttp([500]),
+            )
+        rendered = str(raised.exception)
+        for workload in workloads:
+            self.assertNotIn(f"{workload.id}-secret", rendered)
+
+
+class ReconciliationTests(unittest.TestCase):
+    def test_check_reports_only_safe_field_names(self):
+        workloads = loaded()
+        rows = [current_row(workload) for workload in workloads]
+        rows[0]["rpm_limit"] = 1
+        report = reconcile(
+            "check", workloads, FakeLiteLLM(rows), verify_secret_sinks=False
+        )
+        self.assertEqual(report["status"], "drift")
+        self.assertEqual(report["workloads"][0], {
+            "workload": "runner",
+            "status": "drift",
+            "fields": ["rpm_limit"],
+        })
+        self.assertNotIn("sk-", json.dumps(report))
+
+    def test_legacy_runner_alias_is_renamed_in_place(self):
+        workloads = loaded()
+        rows = [current_row(workload) for workload in workloads]
+        rows[0]["key_alias"] = "fleet-services"
+        rows[0]["metadata"]["purpose"] = "runner-and-coordinator"
+        client = FakeLiteLLM(rows)
+        report = reconcile("apply", workloads, client, verify_secret_sinks=False)
+        self.assertEqual(report["status"], "applied")
+        self.assertEqual(client.rows[0]["key_alias"], "fleet-runner")
+        self.assertEqual(client.rows[0]["metadata"], workloads[0].desired["metadata"])
+        self.assertFalse(any(call[1] == "/key/generate" for call in client.calls))
+
+    def test_duplicate_current_and_legacy_runner_keys_are_refused(self):
+        workload = loaded()[0]
+        rows = [
+            current_row(workload, "fleet-runner"),
+            current_row(workload, "fleet-services"),
+        ]
+        with self.assertRaisesRegex(ReconcileError, "duplicate managed keys"):
+            index_managed_keys(rows, (workload,))
+
+    def test_managed_metadata_recovers_a_renamed_alias_in_place(self):
+        workload = loaded()[0]
+        row = current_row(workload, "fleet-renamed-outside-config")
+        indexed = index_managed_keys([row], (workload,))
+        self.assertEqual(indexed[workload.id].identifier, row["token"])
+
+    def test_unknown_managed_workload_is_refused_as_an_orphan(self):
+        workload = loaded()[0]
+        row = current_row(workload)
+        row["metadata"]["workload"] = "forgotten-workload"
+        with self.assertRaisesRegex(ReconcileError, "unknown workload"):
+            index_managed_keys([row], (workload,))
+
+    def test_missing_key_is_created_and_written_to_coolify(self):
+        workloads = loaded()
+        rows = [current_row(workload) for workload in workloads[1:]]
+        litellm = FakeLiteLLM(rows)
+        coolify = FakeCoolify()
+        report = reconcile(
+            "apply",
+            workloads,
+            litellm,
+            coolify,
+            "unused",
+            verify_secret_sinks=False,
+        )
+        self.assertEqual(report["status"], "applied")
+        created = next(row for row in litellm.rows if row["key_alias"] == "fleet-runner")
+        self.assertFalse(drift_fields(created, workloads[0].desired))
+        self.assertEqual(len(coolify.rows), 1)
+        self.assertEqual(coolify.rows[0]["key"], "LITELLM_API_KEY")
+        self.assertEqual(coolify.rows[0]["value"], SECRET)
+
+    def test_sink_failure_keeps_the_new_key_active_to_avoid_a_dead_secret(self):
+        workloads = loaded()
+        rows = [current_row(workload) for workload in workloads[1:]]
+        litellm = FakeLiteLLM(rows)
+        with self.assertRaisesRegex(ReconcileError, "kept active"):
+            reconcile(
+                "apply",
+                workloads,
+                litellm,
+                FakeCoolify(fail_write=True),
+                "unused",
+                verify_secret_sinks=False,
+            )
+        self.assertTrue(any(row["key_alias"] == "fleet-runner" for row in litellm.rows))
+
+    def test_ambiguous_create_is_discovered_and_revoked(self):
+        workload = loaded()[0]
+        litellm = FakeLiteLLM([], fail_create_after_write=True)
+        with self.assertRaisesRegex(ReconcileError, "key/generate is unavailable"):
+            reconcile(
+                "apply",
+                (workload,),
+                litellm,
+                FakeCoolify(),
+                "unused",
+                verify_secret_sinks=False,
+            )
+        self.assertEqual(litellm.rows, [])
+
+    def test_check_detects_a_coolify_secret_fingerprint_mismatch(self):
+        workload = loaded()[0]
+        litellm = FakeLiteLLM([current_row(workload)])
+        coolify = FakeCoolify()
+        coolify.rows = [
+            {"key": "LITELLM_API_KEY", "value": "wrong-secret", "is_preview": False}
+        ]
+        report = reconcile("check", (workload,), litellm, coolify, "unused")
+        self.assertEqual(report["status"], "drift")
+        self.assertEqual(report["workloads"][0]["sinks"], ["coolify:LITELLM_API_KEY"])
+
+    def test_apply_refuses_sink_mismatch_before_any_key_mutation(self):
+        workload = loaded()[0]
+        litellm = FakeLiteLLM([current_row(workload)])
+        coolify = FakeCoolify()
+        coolify.rows = [
+            {"key": "LITELLM_API_KEY", "value": "wrong-secret", "is_preview": False}
+        ]
+        with self.assertRaisesRegex(ReconcileError, "explicit credential rotation"):
+            reconcile("apply", (workload,), litellm, coolify, "unused")
+        self.assertFalse(any(call[1] in ("/key/generate", "/key/update") for call in litellm.calls))
+
+    def test_explicit_rotation_replaces_a_mismatched_coolify_secret(self):
+        workload = loaded()[0]
+        old = current_row(workload)
+        litellm = FakeLiteLLM([old])
+        coolify = FakeCoolify()
+        coolify.rows = [
+            {"key": "LITELLM_API_KEY", "value": "wrong-secret", "is_preview": False}
+        ]
+        report = reconcile(
+            "rotate",
+            (workload,),
+            litellm,
+            coolify,
+            "unused",
+            rotate_workload="runner",
+        )
+        self.assertEqual(report["status"], "rotated")
+        self.assertEqual(coolify.rows[0]["value"], SECRET)
+        self.assertEqual(len(litellm.rows), 1)
+        self.assertEqual(litellm.rows[0]["key_alias"], "fleet-runner")
+        self.assertNotEqual(litellm.rows[0]["token"], old["token"])
+
+    def test_failed_coolify_rotation_revokes_only_the_candidate(self):
+        workload = loaded()[0]
+        old = current_row(workload)
+        litellm = FakeLiteLLM([old])
+        coolify = FakeCoolify(fail_write=True)
+        coolify.rows = [
+            {"key": "LITELLM_API_KEY", "value": "wrong-secret", "is_preview": False}
+        ]
+        with self.assertRaisesRegex(ReconcileError, "replacement revoked"):
+            reconcile(
+                "rotate",
+                (workload,),
+                litellm,
+                coolify,
+                "unused",
+                rotate_workload="runner",
+            )
+        self.assertEqual(litellm.rows, [old])
+
+    def test_partial_multi_sink_rotation_never_revokes_a_published_candidate(self):
+        base = loaded()[0]
+        first = Sink("coolify_env", "LITELLM_API_KEY_A", application_uuid="app-a")
+        second = Sink("coolify_env", "LITELLM_API_KEY_B", application_uuid="app-b")
+        workload = replace(base, sinks=(first, second))
+        old = current_row(workload)
+        old_secret = f"{workload.id}-secret"
+        litellm = FakeLiteLLM([old])
+        coolify = SelectiveFailCoolify("app-b")
+        coolify.rows = [
+            {"key": first.key, "value": old_secret, "is_preview": False},
+            {"key": second.key, "value": old_secret, "is_preview": False},
+        ]
+
+        with self.assertRaisesRegex(ReconcileError, "kept active"):
+            reconcile(
+                "rotate",
+                (workload,),
+                litellm,
+                coolify,
+                "unused",
+                rotate_workload=workload.id,
+            )
+
+        candidates = [
+            row
+            for row in litellm.rows
+            if row.get("metadata", {}).get("key_role") == "rotation_candidate"
+        ]
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(len(litellm.rows), 2, "old and partially published keys stay active")
+        values = {row["key"]: row["value"] for row in coolify.rows}
+        self.assertEqual(values[first.key], SECRET)
+        self.assertEqual(values[second.key], old_secret)
+
+        with self.assertRaisesRegex(ReconcileError, "partially published"):
+            reconcile(
+                "rotate",
+                (workload,),
+                litellm,
+                coolify,
+                "unused",
+                rotate_workload=workload.id,
+            )
+        self.assertEqual(litellm.generate_count, 1, "retry must not create another candidate")
+
+    def test_next_rotation_finishes_an_identified_published_candidate(self):
+        workload = loaded()[0]
+        old = current_row(workload)
+        candidate_secret = "sk-fleetwork-published-candidate"
+        candidate = {
+            **copy.deepcopy(workload.desired),
+            "key_alias": "fleet-runner-next-deadbeef",
+            "metadata": {
+                **copy.deepcopy(workload.desired["metadata"]),
+                "key_role": "rotation_candidate",
+            },
+            "token": hashlib.sha256(candidate_secret.encode()).hexdigest(),
+        }
+        litellm = FakeLiteLLM([old, candidate])
+        coolify = FakeCoolify()
+        coolify.rows = [
+            {
+                "key": "LITELLM_API_KEY",
+                "value": candidate_secret,
+                "is_preview": False,
+            }
+        ]
+        report = reconcile(
+            "rotate",
+            (workload,),
+            litellm,
+            coolify,
+            "unused",
+            rotate_workload="runner",
+        )
+        self.assertEqual(report["status"], "rotated")
+        self.assertEqual(len(litellm.rows), 1)
+        self.assertEqual(litellm.rows[0]["token"], candidate["token"])
+        self.assertEqual(litellm.rows[0]["key_alias"], "fleet-runner")
+
+    def test_retry_cleans_stale_candidate_without_rotating_current_again(self):
+        workload = loaded()[0]
+        old = current_row(workload)
+        replacement_secret = "sk-fleetwork-published-replacement"
+        stale_secret = "sk-fleetwork-stale-candidate"
+        replacement = {
+            **copy.deepcopy(workload.desired),
+            "key_alias": "fleet-runner-next-replacement",
+            "metadata": {
+                **copy.deepcopy(workload.desired["metadata"]),
+                "key_role": "rotation_candidate",
+            },
+            "token": hashlib.sha256(replacement_secret.encode()).hexdigest(),
+        }
+        stale = {
+            **copy.deepcopy(replacement),
+            "key_alias": "fleet-runner-next-stale",
+            "token": hashlib.sha256(stale_secret.encode()).hexdigest(),
+        }
+        litellm = FakeLiteLLM([old, replacement, stale], fail_delete_call=2)
+        coolify = FakeCoolify()
+        coolify.rows = [{
+            "key": "LITELLM_API_KEY",
+            "value": replacement_secret,
+            "is_preview": False,
+        }]
+        with self.assertRaisesRegex(ReconcileError, "key/delete is unavailable"):
+            reconcile(
+                "rotate",
+                (workload,),
+                litellm,
+                coolify,
+                "unused",
+                rotate_workload="runner",
+            )
+
+        current = next(row for row in litellm.rows if row["key_alias"] == "fleet-runner")
+        self.assertEqual(current["token"], replacement["token"])
+        self.assertEqual(len(litellm.rows), 2)
+
+        report = reconcile(
+            "rotate",
+            (workload,),
+            litellm,
+            coolify,
+            "unused",
+            rotate_workload="runner",
+        )
+        self.assertEqual(report["status"], "rotated")
+        self.assertEqual(len(litellm.rows), 1)
+        self.assertEqual(litellm.generate_count, 0)
+
+
+class SecretSinkTests(unittest.TestCase):
+    @patch("scripts.reconcile_litellm_keys.subprocess.run")
+    def test_github_secret_is_passed_on_stdin_never_argv(self, run):
+        run.side_effect = [
+            subprocess.CompletedProcess([], 0, b"", b""),
+            subprocess.CompletedProcess([], 0, b"", b""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                b'[{"name":"LITELLM_PROBE_KEY","updatedAt":"2026-08-05T20:00:00Z"}]',
+                b"",
+            ),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                json.dumps(
+                    [
+                        {
+                            "name": "LITELLM_PROBE_KEY_SHA256",
+                            "value": hashlib.sha256(SECRET.encode()).hexdigest(),
+                            "updatedAt": "2026-08-05T20:00:01Z",
+                        }
+                    ]
+                ).encode(),
+                b"",
+            ),
+        ]
+        sink = Sink(
+            "github_environment_secret",
+            "LITELLM_PROBE_KEY",
+            repository="FleetWorkAI/.github",
+            environment="production",
+            fingerprint_key="LITELLM_PROBE_KEY_SHA256",
+        )
+        write_github_secret(sink, SECRET, "github-token")
+        first = run.call_args_list[0]
+        self.assertNotIn(SECRET, first.args[0])
+        self.assertEqual(first.kwargs["input"], SECRET.encode())
+        self.assertNotIn(SECRET, repr(first.args[0]))
+
+    @patch("scripts.reconcile_litellm_keys.read_github_sink")
+    def test_github_secret_changed_after_its_fingerprint_is_drift(self, read_sink):
+        workload = loaded()[2]
+        current = current_row(workload)
+        read_sink.return_value = (
+            {"LITELLM_PROBE_KEY": "2026-08-05T20:00:02Z"},
+            {
+                "LITELLM_PROBE_KEY_SHA256": {
+                    "value": current["token"],
+                    "updated_at": "2026-08-05T20:00:01Z",
+                }
+            },
+        )
+        drift = inspect_secret_sinks(
+            (workload,),
+            {workload.id: type("Current", (), {"identifier": current["token"]})()},
+            None,
+            "github-token",
+        )
+        self.assertEqual(drift, {"catalog-probe": ["github:LITELLM_PROBE_KEY"]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Lot 2 du plan, partie ops. **Empilée sur #36**, à merger après elle.

## Ce que ça fait

**Quatre clés virtuelles par workload** remplacent la clé unique qui donnait à chaque service l'accès à tous les modèles et à toutes les routes du proxy :

| Workload | Modèles | Routes |
|---|---|---|
| `runner` | les six alias de chat plus l'embedding | complétion, embedding, lecture des modèles |
| `coordinator` | `gpt-5-nano` seul | complétion |
| `catalog-probe` | les six alias de chat | complétion, lecture des modèles |
| `spend-reader` | aucun | `/spend/logs` seulement |

Le script réconcilie l'état réel du proxy avec ce fichier, et **refuse de tourner si les modèles déclarés ne correspondent pas au catalogue gouverné**. C'est ce contrôle croisé qui empêche une clé de dériver : il compare deux décisions, pas deux copies d'une même donnée.

**La configuration globale est verrouillée.** `drop_params` autorisait le proxy à retirer silencieusement un paramètre qu'un endpoint amont ne comprend pas. Appliqué à une politique de confidentialité ou à un plafond de sortie, cela veut dire qu'une garantie disparaît de la requête sans que personne ne le sache, et que la réponse revient quand même : le succès devient la preuve que le contrôle a sauté. Le desired state versionné pose `drop_params: false`, et le script signale tout écart sans jamais le corriger en silence.

## Preuve

68 tests, rejoués sur un arbre extrait du commit. La validation de PR reste déterministe : tests unitaires et compilation, aucun appel à la production, à OpenRouter ou à LiteLLM.

## À savoir

Le périmètre exécutable inclut les alias dépréciés. `selectable` gouverne ce que l'interface propose, pas ce qu'une clé doit autoriser : exclure un alias déprécié couperait les agents déjà configurés dessus le jour même de la dépréciation, au lieu de les laisser drainer jusqu'au retrait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Remplace la #37, que GitHub a ferme automatiquement quand la branche de base `feat/coolify-deploy-gate` a ete supprimee au merge de la #36. La branche est rebasee sur `main` : les deux commits de la porte de deploiement sont tombes, seuls les quatre commits LiteLLM restent.
