### PR TITLE
fix(ci): la porte prouvait le redemarrage sur un champ toujours vide

### DIFF
--- a/scripts/deploy_coolify.py
+++ b/scripts/deploy_coolify.py
@@ -21,6 +21,20 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SUCCESS = "success"
 TERMINAL_FAILURES = {"cancelled", "error", "failed"}
 
+# Horodatages que Coolify est susceptible d'avancer quand un conteneur revient
+# en ligne, du plus fiable au moins fiable.
+#
+# `last_restart_at` vaut toujours `null` sur l'instance LanaCool. Un contrôle
+# fondé sur lui seul refusait donc TOUT déploiement réel, y compris ceux qui
+# avaient parfaitement abouti : mesuré le 2026-08-07 sur un déploiement du
+# runner terminé, conteneur sain, journaux frais, refusé par ce seul contrôle.
+# Le test qui le couvrait passait parce que sa donnée d'exemple renseignait un
+# champ que l'API ne renseigne jamais.
+#
+# `last_online_at` est celui que Coolify avance réellement, et il dit
+# exactement ce qu'on cherche à prouver : le conteneur est revenu en ligne.
+RESTART_MARKER_FIELDS = ("last_online_at", "last_restart_at")
+
 
 class GateError(RuntimeError):
     """A validation or deployment invariant failed."""
@@ -269,6 +283,20 @@ def wait_for_terminal(
     raise GateError(f"deployment {deploy_uuid} did not finish before timeout")
 
 
+def restart_marker(app: dict[str, Any]) -> tuple[str, str] | None:
+    """Le premier horodatage de redémarrage réellement renseigné, avec son nom.
+
+    Renvoie le nom du champ en plus de sa valeur : sans lui, une valeur lue
+    dans un champ avant le déploiement et dans un autre après passerait pour
+    un changement, alors qu'elle ne prouve rien.
+    """
+    for field in RESTART_MARKER_FIELDS:
+        value = app.get(field)
+        if isinstance(value, str) and value.strip():
+            return field, value
+    return None
+
+
 def deploy_target(
     coolify: JsonClient,
     service: Service,
@@ -278,7 +306,7 @@ def deploy_target(
     poll_seconds: int,
 ) -> str:
     before = preflight_target(coolify, service, target)
-    previous_restart = before.get("last_restart_at")
+    previous_restart = restart_marker(before)
     coolify.patch(f"/applications/{target.uuid}", {"git_commit_sha": sha})
     pinned = coolify.get(f"/applications/{target.uuid}")
     if not isinstance(pinned, dict) or str(pinned.get("git_commit_sha", "")).lower() != sha:
@@ -294,8 +322,12 @@ def deploy_target(
         raise GateError(f"{target.name} no longer pins the approved SHA")
     if "running" not in str(after.get("status", "")):
         raise GateError(f"{target.name} is not running after deployment")
-    current_restart = after.get("last_restart_at")
-    if not current_restart or current_restart == previous_restart:
+    current_restart = restart_marker(after)
+    if current_restart is None:
+        raise GateError(f"{target.name} exposes no restart timestamp to compare")
+    if previous_restart is not None and previous_restart[0] != current_restart[0]:
+        raise GateError(f"{target.name} switched restart timestamp field mid-deployment")
+    if current_restart == previous_restart:
         raise GateError(f"{target.name} has no fresh restart marker")
     logs_payload = coolify.get(f"/applications/{target.uuid}/logs?lines=200")
     logs = logs_payload.get("logs", "") if isinstance(logs_payload, dict) else str(logs_payload)

--- a/tests/test_deploy_coolify.py
+++ b/tests/test_deploy_coolify.py
@@ -14,6 +14,7 @@ from scripts.deploy_coolify import (
     deploy_target,
     load_service,
     preflight_target,
+    restart_marker,
     validate_sha,
     verify_github,
 )
@@ -159,15 +160,23 @@ class CoolifyGateTests(unittest.TestCase):
 
     @patch("scripts.deploy_coolify.time.sleep", return_value=None)
     def test_deploy_pins_sha_and_proves_fresh_boot(self, _sleep):
+        # Forme réelle de l'API LanaCool : `last_restart_at` reste null, c'est
+        # `last_online_at` qui avance. L'ancienne version de ce test renseignait
+        # `last_restart_at`, donc elle validait le code contre une fiction.
         app_before = {
             "name": "agent-runner",
             "git_repository": "FleetWorkAI/agent-runner",
             "git_branch": "main",
             "git_commit_sha": "HEAD",
-            "last_restart_at": "before",
+            "last_online_at": "2026-08-07 18:09:31",
+            "last_restart_at": None,
             "status": "running:healthy",
         }
-        app_after = {**app_before, "git_commit_sha": SHA, "last_restart_at": "after"}
+        app_after = {
+            **app_before,
+            "git_commit_sha": SHA,
+            "last_online_at": "2026-08-07 18:56:56",
+        }
         client = FakeClient(
             {
                 ("GET", "/applications/runner-uuid"): (app_before, app_after, app_after),
@@ -183,6 +192,65 @@ class CoolifyGateTests(unittest.TestCase):
         self.assertEqual(deploy_id, "dep-1")
         self.assertIn(("PATCH", "/applications/runner-uuid", {"git_commit_sha": SHA}), client.calls)
 
+    def test_restart_marker_names_the_field_it_read(self):
+        self.assertEqual(
+            restart_marker({"last_online_at": "2026-08-07 18:56:56"}),
+            ("last_online_at", "2026-08-07 18:56:56"),
+        )
+        self.assertEqual(
+            restart_marker({"last_online_at": None, "last_restart_at": "x"}),
+            ("last_restart_at", "x"),
+        )
+        self.assertIsNone(restart_marker({"last_online_at": None, "last_restart_at": None}))
+        self.assertIsNone(restart_marker({"last_online_at": "   "}))
+
+    @patch("scripts.deploy_coolify.time.sleep", return_value=None)
+    def test_deployment_without_any_restart_timestamp_is_refused(self, _sleep):
+        # Le cas réel du 2026-08-07 : Coolify laisse les deux champs à null.
+        # La porte doit refuser plutôt que de croire le conteneur redémarré.
+        app_before = {
+            "name": "agent-runner",
+            "git_repository": "FleetWorkAI/agent-runner",
+            "git_branch": "main",
+            "git_commit_sha": "HEAD",
+            "last_online_at": None,
+            "last_restart_at": None,
+            "status": "running:healthy",
+        }
+        app_after = {**app_before, "git_commit_sha": SHA}
+        client = FakeClient(
+            {
+                ("GET", "/applications/runner-uuid"): (app_before, app_after, app_after),
+                ("GET", "/applications/runner-uuid/envs"): [{"key": "ONE"}],
+                ("GET", "/deploy?uuid=runner-uuid&force=false"): {"deployment_uuid": "dep-1"},
+                ("GET", "/deployments/dep-1"): {"status": "finished", "commit": SHA},
+            }
+        )
+        with self.assertRaisesRegex(GateError, "exposes no restart timestamp"):
+            deploy_target(client, service(), service().targets[0], SHA, 1, 0)
+
+    @patch("scripts.deploy_coolify.time.sleep", return_value=None)
+    def test_unchanged_restart_timestamp_is_refused(self, _sleep):
+        # Le conteneur n'a pas redémarré : même horodatage avant et après.
+        app = {
+            "name": "agent-runner",
+            "git_repository": "FleetWorkAI/agent-runner",
+            "git_branch": "main",
+            "git_commit_sha": SHA,
+            "last_online_at": "2026-08-07 18:09:31",
+            "status": "running:healthy",
+        }
+        client = FakeClient(
+            {
+                ("GET", "/applications/runner-uuid"): (app, app, app),
+                ("GET", "/applications/runner-uuid/envs"): [{"key": "ONE"}],
+                ("GET", "/deploy?uuid=runner-uuid&force=false"): {"deployment_uuid": "dep-1"},
+                ("GET", "/deployments/dep-1"): {"status": "finished", "commit": SHA},
+            }
+        )
+        with self.assertRaisesRegex(GateError, "no fresh restart marker"):
+            deploy_target(client, service(), service().targets[0], SHA, 1, 0)
+
     @patch("scripts.deploy_coolify.time.sleep", return_value=None)
     def test_deployment_commit_mismatch_is_refused(self, _sleep):
         app = {
@@ -190,7 +258,7 @@ class CoolifyGateTests(unittest.TestCase):
             "git_repository": "FleetWorkAI/agent-runner",
             "git_branch": "main",
             "git_commit_sha": SHA,
-            "last_restart_at": "before",
+            "last_online_at": "2026-08-07 18:09:31",
             "status": "running:healthy",
         }
         client = FakeClient(


### PR DESCRIPTION
## Ce que ça corrige

Le contrôle final de `deploy_target` lisait `last_restart_at`. Sur l'instance
LanaCool ce champ vaut **toujours `null`**, donc `if not current_restart` était
toujours vrai : **la porte refusait 100 % des déploiements réels.**

## Comment on l'a su

Un vrai déploiement du runner, lancé le 2026-08-07 sur le commit qui tournait
déjà (`99acbc11`), pour prouver le chemin réel avant de couper
l'auto-déploiement.

Le dispatcher a fait tout son travail : SHA épinglé, build lancé, neuf minutes
d'attente, Coolify `finished`, commit déployé vérifié. Puis refus sur le dernier
contrôle :

```text
deployment fgz6hgsp3gbrsph82xmzj1rb: finished
deployment gate refused: agent-runner has no fresh restart marker
```

Or le runner avait parfaitement redémarré : `running:healthy`, journaux frais à
18:55:22 avec `http server listening addr=0.0.0.0:8080`.

## Pourquoi rien ne l'avait vu

Le mode à blanc s'arrête avant d'écrire `git_commit_sha`, de déclencher le build
et de relire l'application. Il ne pouvait pas atteindre ce contrôle.

Et le test qui le couvrait passait parce que sa donnée d'exemple renseignait
`last_restart_at`, un champ que l'API ne renseigne jamais. **Il validait le code
contre une fiction.**

## Le correctif

Lire le premier horodatage réellement renseigné parmi `last_online_at` puis
`last_restart_at`, et retenir le **nom** du champ à côté de sa valeur. Sans ce
nom, une valeur lue dans un champ avant le déploiement et dans un autre après
passerait pour un changement, alors qu'elle ne prouve rien.

Trois refus distincts remplacent l'unique message : aucun champ renseigné,
changement de champ en cours de route, horodatage inchangé.

## Preuve

Donnée d'exemple corrigée pour prendre la forme réelle de l'API, plus trois cas
nouveaux, dont celui qui **reproduit la panne** : les deux champs à `null`
doivent être refusés.

**Sabotage vérifié** : remettre `last_restart_at` seul fait tomber 3 tests, le
restaurer les fait repasser. 22 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)