### PR TITLE
Lot 0 · imposer l'ordre de deploiement dans le script, pas dans un plan

### DIFF
--- a/config/coolify-services.json
+++ b/config/coolify-services.json
@@ -1,6 +1,41 @@
 {
   "schemaVersion": 1,
   "services": {
+    "agent-runner": {
+      "repository": "FleetWorkAI/agent-runner",
+      "requiredChecks": [
+        "cargo test",
+        "cargo build --release",
+        "Secrets (gitleaks)",
+        "Dependencies (cargo audit)"
+      ],
+      "targets": [
+        {
+          "name": "agent-runner",
+          "uuid": "yi0o3a7wwmc3bv5hhjx15ppi",
+          "bootMarker": "starting fleetwork orchestrator"
+        }
+      ],
+      "requires": []
+    },
+    "agent-coordinator": {
+      "repository": "FleetWorkAI/agent-coordinator",
+      "requiredChecks": [
+        "cargo test",
+        "Secrets (gitleaks)",
+        "Dependencies (cargo audit)"
+      ],
+      "targets": [
+        {
+          "name": "agent-coordinator",
+          "uuid": "ryhnzym3sqnv34qa7sh9i4ol",
+          "bootMarker": "starting fleetwork memory-session-layer"
+        }
+      ],
+      "requires": [
+        "agent-runner"
+      ]
+    },
     "web-worker": {
       "repository": "FleetWorkAI/fleetwork-web",
       "requiredChecks": [
@@ -19,37 +54,9 @@
           "uuid": "vq0yi3n9ldy1k4nxwywye9ge",
           "bootMarker": "\\[worker\\] démarré"
         }
-      ]
-    },
-    "agent-runner": {
-      "repository": "FleetWorkAI/agent-runner",
-      "requiredChecks": [
-        "cargo test",
-        "cargo build --release",
-        "Secrets (gitleaks)",
-        "Dependencies (cargo audit)"
       ],
-      "targets": [
-        {
-          "name": "agent-runner",
-          "uuid": "yi0o3a7wwmc3bv5hhjx15ppi",
-          "bootMarker": "starting fleetwork orchestrator"
-        }
-      ]
-    },
-    "agent-coordinator": {
-      "repository": "FleetWorkAI/agent-coordinator",
-      "requiredChecks": [
-        "cargo test",
-        "Secrets (gitleaks)",
-        "Dependencies (cargo audit)"
-      ],
-      "targets": [
-        {
-          "name": "agent-coordinator",
-          "uuid": "ryhnzym3sqnv34qa7sh9i4ol",
-          "bootMarker": "starting fleetwork memory-session-layer"
-        }
+      "requires": [
+        "agent-coordinator"
       ]
     }
   }

--- a/scripts/deploy_coolify.py
+++ b/scripts/deploy_coolify.py
@@ -104,6 +104,9 @@ class Service:
     repository: str
     required_checks: tuple[str, ...]
     targets: tuple[Target, ...]
+    # Services qui doivent deja tourner au sommet de leur `main` avant que
+    # celui-ci parte. Voir `verify_prerequisites`.
+    requires: tuple[str, ...] = ()
 
 
 def load_service(config_path: Path, service_name: str) -> Service:
@@ -143,11 +146,22 @@ def load_service(config_path: Path, service_name: str) -> Service:
             raise GateError(f"invalid boot marker for {name}") from error
         seen_uuids.add(uuid)
         targets.append(Target(name=name, uuid=uuid, boot_marker=marker))
+    requires = raw.get("requires", [])
+    if not isinstance(requires, list) or any(not isinstance(item, str) for item in requires):
+        raise GateError("requires must be a list of service names")
+    if len(set(requires)) != len(requires):
+        raise GateError("requires contains duplicates")
+    for name in requires:
+        if name == service_name:
+            raise GateError(f"service {service_name!r} cannot require itself")
+        if name not in config["services"]:
+            raise GateError(f"unknown prerequisite {name!r} for {service_name!r}")
     return Service(
         name=service_name,
         repository=repository,
         required_checks=tuple(checks),
         targets=tuple(targets),
+        requires=tuple(requires),
     )
 
 
@@ -207,6 +221,54 @@ def verify_github(github: JsonClient, service: Service, sha: str) -> None:
     if not isinstance(main, dict) or str(main.get("sha", "")).lower() != sha:
         raise GateError(f"{sha[:8]} is not the current main of {service.repository}")
     verify_required_checks(github, service.repository, sha, service.required_checks)
+
+
+def verify_prerequisites(
+    config_path: Path,
+    coolify: JsonClient,
+    github: JsonClient,
+    service: Service,
+) -> None:
+    """Refuse de deployer un service dont un prerequis est en retard.
+
+    POURQUOI CETTE GARDE EXISTE
+    Le coordinateur ecrit `effort_tier` et `model_variant` dans le snapshot
+    durable ; le runner porte la fonction SQL qui decide si ce snapshot est
+    normalise. Deployer le coordinateur avant le runner ne perd pas un champ :
+    `job_snapshot_is_normalized` rend `false` et `admit_run` refuse alors
+    100 % des admissions, de toutes les societes, chat et Kanban confondus.
+
+    Jusqu'au 2026-08-08 cet ordre n'existait que dans un plan. Le script prend
+    `--service`, un seul a la fois, donc rien n'empechait de le prendre a
+    l'envers : se tromper etait un clic, pas une erreur detectee.
+
+    LA REGLE, ET SON PRIX
+    Un prerequis doit tourner au SOMMET de son propre `main`. La regle est plus
+    stricte que « le prerequis porte la migration dont j'ai besoin », qu'aucune
+    machine ne sait evaluer. Consequence assumee : un commit sans rapport pousse
+    sur le depot du prerequis bloque ce deploiement jusqu'a ce que le prerequis
+    parte aussi. C'est le bon sens de l'echec · deployer le runner d'abord est
+    precisement ce qu'on veut, et l'inverse arrete la production.
+    """
+    for name in service.requires:
+        prerequis = load_service(config_path, name)
+        repo_path = "/repos/" + urllib.parse.quote(prerequis.repository, safe="/")
+        main = github.get(f"{repo_path}/commits/main")
+        if not isinstance(main, dict) or not isinstance(main.get("sha"), str):
+            raise GateError(f"cannot read main of {prerequis.repository}")
+        attendu = str(main["sha"]).lower()
+        for target in prerequis.targets:
+            application = coolify.get(f"/applications/{target.uuid}")
+            if not isinstance(application, dict):
+                raise GateError(f"invalid Coolify application {target.name}")
+            deploye = str(application.get("git_commit_sha", "")).lower()
+            if deploye != attendu:
+                raise GateError(
+                    f"prerequisite {name} is behind: {target.name} runs "
+                    f"{deploye[:8] or 'nothing'} but {prerequis.repository} main is "
+                    f"{attendu[:8]}. Deploy {name} first: taking this order backwards "
+                    f"makes admit_run refuse every run."
+                )
 
 
 def env_keys(rows: Any) -> list[tuple[str, bool]]:
@@ -360,6 +422,9 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     if not coolify_url.startswith("https://") or not coolify_token:
         raise GateError("COOLIFY_URL and COOLIFY_API_TOKEN are required")
     coolify = JsonClient(f"{coolify_url}/api/v1", coolify_token, "fleetwork-deploy-gate/1")
+    # Avant le vol a blanc comme avant le vrai deploiement : un « validated »
+    # rendu sur un ordre faux serait un feu vert pour la panne.
+    verify_prerequisites(args.config, coolify, github, service)
     if args.dry_run:
         for target in service.targets:
             preflight_target(coolify, service, target)

--- a/tests/test_deploy_coolify.py
+++ b/tests/test_deploy_coolify.py
@@ -15,8 +15,10 @@ from scripts.deploy_coolify import (
     load_service,
     preflight_target,
     restart_marker,
+    run,
     validate_sha,
     verify_github,
+    verify_prerequisites,
 )
 
 
@@ -64,6 +66,150 @@ def check(name, conclusion="success", run_id=1):
         "conclusion": conclusion,
         "app": {"slug": "github-actions"},
     }
+
+
+def deux_services(requires=("amont",)):
+    """Un aval qui exige un amont, et l'amont lui-meme."""
+    return {
+        "schemaVersion": 1,
+        "services": {
+            "amont": {
+                "repository": "FleetWorkAI/agent-runner",
+                "requiredChecks": ["CI"],
+                "targets": [{"name": "amont-app", "uuid": "amont-uuid", "bootMarker": "ready"}],
+            },
+            "aval": {
+                "repository": "FleetWorkAI/agent-coordinator",
+                "requiredChecks": ["CI"],
+                "targets": [{"name": "aval-app", "uuid": "aval-uuid", "bootMarker": "ready"}],
+                "requires": list(requires),
+            },
+        },
+    }
+
+
+class PrerequisiteTests(unittest.TestCase):
+    """L'ordre de deploiement, impose par le script et non par un plan.
+
+    Deployer le coordinateur avant le runner ne perd pas un champ : la fonction
+    SQL rend `false` et `admit_run` refuse 100 % des admissions. Jusqu'ici cet
+    ordre n'existait que dans un document, et le script prend `--service`, un
+    seul a la fois : se tromper etait un clic.
+    """
+
+    def _config(self, contenu):
+        directory = tempfile.mkdtemp()
+        path = Path(directory) / "config.json"
+        path.write_text(json.dumps(contenu))
+        return path
+
+    def test_prerequisite_a_jour_laisse_passer(self):
+        # Contrôle POSITIF. Sans lui, un refus systematique passerait le test
+        # negatif ci-dessous tout en bloquant tous les deploiements.
+        path = self._config(deux_services())
+        aval = load_service(path, "aval")
+        github = FakeClient({("GET", "/repos/FleetWorkAI/agent-runner/commits/main"): {"sha": SHA}})
+        coolify = FakeClient({("GET", "/applications/amont-uuid"): {"git_commit_sha": SHA}})
+        verify_prerequisites(path, coolify, github, aval)
+
+    def test_prerequisite_en_retard_est_refuse(self):
+        path = self._config(deux_services())
+        aval = load_service(path, "aval")
+        github = FakeClient({("GET", "/repos/FleetWorkAI/agent-runner/commits/main"): {"sha": SHA}})
+        coolify = FakeClient({("GET", "/applications/amont-uuid"): {"git_commit_sha": "b" * 40}})
+        with self.assertRaisesRegex(GateError, "prerequisite amont is behind"):
+            verify_prerequisites(path, coolify, github, aval)
+
+    def test_message_de_refus_dit_quoi_faire(self):
+        # Une porte qui refuse sans dire dans quel sens aller se contourne.
+        path = self._config(deux_services())
+        aval = load_service(path, "aval")
+        github = FakeClient({("GET", "/repos/FleetWorkAI/agent-runner/commits/main"): {"sha": SHA}})
+        coolify = FakeClient({("GET", "/applications/amont-uuid"): {"git_commit_sha": ""}})
+        with self.assertRaises(GateError) as capture:
+            verify_prerequisites(path, coolify, github, aval)
+        message = str(capture.exception)
+        self.assertIn("Deploy amont first", message)
+        self.assertIn("refuse every run", message)
+
+    def test_sans_prerequis_aucun_appel_reseau(self):
+        path = self._config(deux_services(requires=()))
+        aval = load_service(path, "aval")
+        github, coolify = FakeClient(), FakeClient()
+        verify_prerequisites(path, coolify, github, aval)
+        self.assertEqual(github.calls, [])
+        self.assertEqual(coolify.calls, [])
+
+    def test_prerequis_inconnu_est_refuse_au_chargement(self):
+        path = self._config(deux_services(requires=("fantome",)))
+        with self.assertRaisesRegex(GateError, "unknown prerequisite"):
+            load_service(path, "aval")
+
+    def test_un_service_ne_peut_pas_s_exiger_lui_meme(self):
+        path = self._config(deux_services(requires=("aval",)))
+        with self.assertRaisesRegex(GateError, "cannot require itself"):
+            load_service(path, "aval")
+
+    def _run_avec(self, sha_amont_deploye, dry_run):
+        """Joue `run()` de bout en bout, avec les deux clients simules."""
+        path = self._config(deux_services())
+        aval_repo = "/repos/FleetWorkAI/agent-coordinator"
+        github = FakeClient(
+            {
+                ("GET", f"{aval_repo}/commits/main"): {"sha": SHA},
+                ("GET", f"{aval_repo}/commits/{SHA}/check-runs?filter=latest&per_page=100"): {
+                    "total_count": 1,
+                    "check_runs": [check("CI")],
+                },
+                ("GET", "/repos/FleetWorkAI/agent-runner/commits/main"): {"sha": SHA},
+            }
+        )
+        coolify = FakeClient(
+            {
+                ("GET", "/applications/amont-uuid"): {"git_commit_sha": sha_amont_deploye},
+                ("GET", "/applications/aval-uuid"): {
+                    "name": "aval-app",
+                    "git_repository": "FleetWorkAI/agent-coordinator",
+                    "git_branch": "main",
+                },
+                ("GET", "/applications/aval-uuid/envs"): [],
+            }
+        )
+        args = argparse.Namespace(
+            config=path,
+            service="aval",
+            sha=SHA,
+            dry_run=dry_run,
+            timeout_seconds=1,
+            poll_seconds=0,
+        )
+        environnement = {
+            "FLEETWORK_GITHUB_READ_TOKEN": "jeton",
+            "COOLIFY_URL": "https://coolify.test",
+            "COOLIFY_API_TOKEN": "jeton",
+        }
+        with patch.dict(os.environ, environnement, clear=False):
+            with patch("scripts.deploy_coolify.JsonClient", side_effect=[github, coolify]):
+                return run(args)
+
+    def test_la_porte_est_branchee_sur_run(self):
+        # Une garde testee mais jamais appelee est une garde absente. Ce test
+        # passe par `run()`, donc il tombe si quelqu'un retire l'appel.
+        with self.assertRaisesRegex(GateError, "prerequisite amont is behind"):
+            self._run_avec("b" * 40, dry_run=True)
+
+    def test_le_vol_a_blanc_ne_valide_pas_un_ordre_faux(self):
+        # Un « validated » rendu sur un ordre inverse serait un feu vert pour la
+        # panne : c'est justement le mode qu'on utilise pour se rassurer.
+        resultat = self._run_avec(SHA, dry_run=True)
+        self.assertEqual(resultat["status"], "validated")
+
+    def test_la_configuration_livree_declare_la_chaine_reelle(self):
+        # Le fichier de production, pas une maquette : c'est lui qui protege.
+        reel = Path(__file__).resolve().parents[1] / "config" / "coolify-services.json"
+        self.assertEqual(load_service(reel, "agent-runner").requires, ())
+        self.assertEqual(load_service(reel, "agent-coordinator").requires, ("agent-runner",))
+        self.assertEqual(load_service(reel, "web-worker").requires, ("agent-coordinator",))
 
 
 class ConfigTests(unittest.TestCase):


### PR DESCRIPTION
L'ordre runner puis coordinateur puis web n'existait que dans un document. Le script prend `--service`, un seul a la fois, et la seule boucle porte sur les cibles d'un meme service : **rien n'imposait l'ordre entre services**, donc se tromper etait un clic, pas une erreur detectee.

Ce que la panne coute : le coordinateur ecrit `effort_tier` et `model_variant` dans le snapshot durable, le runner porte la fonction SQL qui decide si ce snapshot est normalise. A l'envers, `job_snapshot_is_normalized` rend `false` et `admit_run` refuse **100 % des admissions**, de toutes les societes, chat et Kanban confondus. Ce n'est pas un champ perdu, c'est un arret total.

## Ce que ca ajoute

`requires` dans `coolify-services.json` (`agent-runner` puis `agent-coordinator` puis `web-worker`), et une porte qui refuse quand un prerequis ne tourne pas au SOMMET de son propre `main`.

La regle est plus stricte que « le prerequis porte la migration dont j'ai besoin », qu'aucune machine ne sait evaluer. Consequence assumee : un commit sans rapport sur le depot amont bloque le deploiement aval jusqu'a ce que l'amont parte aussi. C'est le bon sens de l'echec.

La verification tourne **avant le vol a blanc** comme avant le vrai deploiement : un « validated » rendu sur un ordre inverse serait un feu vert pour la panne, et c'est justement le mode qu'on utilise pour se rassurer.

## Verification

80 tests, 0 echec.

| Sabotage | Tombe |
| --- | --- |
| debrancher la garde de `run()` | le test qui passe par `run()` |
| vider `requires` dans la config LIVREE | le test qui lit le vrai fichier |
| neutraliser la comparaison | 3 tests |

Le premier est celui qui comptait : **aucun test ne couvrait `run()`** avant cette PR, donc la garde aurait pu exister, etre testee, et n'etre jamais appelee.

Le controle positif est present : un prerequis a jour laisse passer. Sans lui, un refus systematique passerait les tests negatifs tout en bloquant tout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)